### PR TITLE
Updates to prettify status and compare

### DIFF
--- a/mepo.d/command/compare/compare.py
+++ b/mepo.d/command/compare/compare.py
@@ -2,29 +2,35 @@ from state.state import MepoState
 from utilities import colors
 from utilities.version import version_to_string
 from repository.git import GitRepository
+from shutil import get_terminal_size
 
 VER_LEN = 30
 
 def run(args):
     allcomps = MepoState.read_state()
     max_namelen = len(max([x.name for x in allcomps], key=len))
+    max_origlen = len(max([version_to_string(x.version) for x in allcomps], key=len))
     for comp in allcomps:
         git = GitRepository(comp.remote, comp.local)
         curr_ver = version_to_string(git.get_version())
         orig_ver = version_to_string(comp.version)
-        print_cmp(comp.name, orig_ver, curr_ver, max_namelen)
+        print_cmp(comp.name, orig_ver, curr_ver, max_namelen, max_origlen)
 
-def print_cmp(name, orig, curr, name_width):
+def print_cmp(name, orig, curr, name_width, orig_width):
     name_blank = ''
     if orig not in curr:
         name = colors.RED + name + colors.RESET
         name_blank = colors.RED + name_blank + colors.RESET
         name_width += len(colors.RED) + len(colors.RESET)
-    FMT_VAL = (name_width, name_width, VER_LEN)
+    FMT_VAL = (name_width, name_width, orig_width)
+
     FMT0 = '{:<%s.%ss} | {:<%ss} | {:<s}' % FMT_VAL
     FMT1 = '{:<%s.%ss} | {:<%ss}' % FMT_VAL
     FMT2 = '{:<%s.%ss} | {:>%ss} | {:<s}' % FMT_VAL
-    if len(orig) > VER_LEN:
+
+    columns, lines = get_terminal_size(fallback=(80,20))
+
+    if len(FMT0.format(name, orig, curr)) > columns:
         print(FMT1.format(name, orig + ' ...'))
         print(FMT2.format(name_blank, '...', curr))
     else:

--- a/mepo.d/utilities/colors.py
+++ b/mepo.d/utilities/colors.py
@@ -1,5 +1,17 @@
-RED   = "\x1b[1;31m"
-BLUE  = "\x1b[1;34m"
-CYAN  = "\x1b[1;36m"
-GREEN = "\x1b[0;32m"
-RESET = "\x1b[0;0m"
+try:
+    import colorama
+    from colorama import Fore, Back, Style
+
+    RED    = Fore.RED
+    BLUE   = Fore.BLUE
+    CYAN   = Fore.CYAN
+    GREEN  = Fore.GREEN
+    YELLOW = Fore.YELLOW
+    RESET  = Style.RESET_ALL
+except ImportError:
+    RED    = "\x1b[1;31m"
+    BLUE   = "\x1b[1;34m"
+    CYAN   = "\x1b[1;36m"
+    GREEN  = "\x1b[1;32m"
+    YELLOW = "\x1b[1;33m"
+    RESET  = "\x1b[0;0m"


### PR DESCRIPTION
A number of updates.
1. Use colorama in colors.py if available and add yellow
2. Make `mepo status` be more verbose by parsing the `git status --porcelain=v2` output.
Before:
```
$ mepo status
Checking status...
ESMA_env               | (t) v1.4.0 (DH)
   | ?? jalsdkf
ESMA_cmake             | (t) v1.0.10 (DH)
ecbuild                | (b) origin/feature/FindMKL-portability-improvement (DH)
FMS                    | (t) geos/orphan/v1.0.3 (DH)
GMAO_Shared            | (t) v1.0.13 (DH)
FVdycoreCubed_GridComp | (t) v1.0.8 (DH)
fvdycore               | (t) geos/v1.0.2 (DH)
MAPL                   | (t) v1.1.12 (DH)
   |  M GMAO_pFIO/tests/test_RequestDataMessage.pf
   |  D README.md
   | RD CHANGELOG.md -> yaya
   | ?? bobo
```
After (there is color in this that GitHub can't see):
```
$ mepo status
Checking status...
ESMA_env               | (t) v1.4.0 (DH)
   | jalsdkf: untracked file
ESMA_cmake             | (t) v1.0.10 (DH)
ecbuild                | (b) origin/feature/FindMKL-portability-improvement (DH)
FMS                    | (t) geos/orphan/v1.0.3 (DH)
GMAO_Shared            | (t) v1.0.13 (DH)
FVdycoreCubed_GridComp | (t) v1.0.8 (DH)
fvdycore               | (t) geos/v1.0.2 (DH)
MAPL                   | (t) v1.1.12 (DH)
   | GMAO_pFIO/tests/test_RequestDataMessage.pf: modified, not staged
   |                                  README.md: deleted, not staged
   |                               CHANGELOG.md: renamed, staged as yaya but deleted, not staged
   |                                       bobo: untracked file
```
3. Make `mepo compare` terminal aware so if you have the width, you can
use it. Before:
```
$ mepo compare
ESMA_env               | (t) v1.4.0 (DH)                | (t) v1.4.0 (DH)
ESMA_cmake             | (t) v1.0.10 (DH)               | (t) v1.0.10 (DH)
ecbuild                | (b) origin/feature/FindMKL-portability-improvement (DH) ...
                       |                            ... | (b) origin/feature/FindMKL-portability-improvement (DH)
FMS                    | (t) geos/orphan/v1.0.3 (DH)    | (t) geos/orphan/v1.0.3 (DH)
GMAO_Shared            | (t) v1.0.13 (DH)               | (t) v1.0.13 (DH)
FVdycoreCubed_GridComp | (t) v1.0.8 (DH)                | (t) v1.0.8 (DH)
fvdycore               | (t) geos/v1.0.2 (DH)           | (t) geos/v1.0.2 (DH)
MAPL                   | (t) v1.1.12 (DH)               | (t) v1.1.12 (DH)
```
After:
```
$ mepo compare
ESMA_env               | (t) v1.4.0 (DH)                                         | (t) v1.4.0 (DH)
ESMA_cmake             | (t) v1.0.10 (DH)                                        | (t) v1.0.10 (DH)
ecbuild                | (b) origin/feature/FindMKL-portability-improvement (DH) | (b) origin/feature/FindMKL-portability-improvement (DH)
FMS                    | (t) geos/orphan/v1.0.3 (DH)                             | (t) geos/orphan/v1.0.3 (DH)
GMAO_Shared            | (t) v1.0.13 (DH)                                        | (t) v1.0.13 (DH)
FVdycoreCubed_GridComp | (t) v1.0.8 (DH)                                         | (t) v1.0.8 (DH)
fvdycore               | (t) geos/v1.0.2 (DH)                                    | (t) geos/v1.0.2 (DH)
MAPL                   | (t) v1.1.12 (DH)                                        | (t) v1.1.12 (DH)
```