### PR TITLE
Handle mepo-cd failure gracefully

### DIFF
--- a/etc/mepo-cd.bash
+++ b/etc/mepo-cd.bash
@@ -7,5 +7,9 @@ function mepo-cd () {
         usage_
         return 1
     fi
-    cd $(mepo whereis $1)
+    if mepo whereis $1; then
+       cd $(mepo whereis $1)
+    else
+       return 1
+    fi
 }

--- a/mepo.d/utilities/verify.py
+++ b/mepo.d/utilities/verify.py
@@ -2,4 +2,4 @@ def valid_components(specified_comp_names, allcomps):
     allnames = [x.name for x in allcomps]
     for compname in specified_comp_names:
         if compname not in allnames:
-            raise Exception('Unknown component name [{}]'.format(compname))
+            raise SystemExit('Unknown component name [{}]'.format(compname))


### PR DESCRIPTION
The issue was that if you did `mepo-cd blabla` and blabla isn't a component, it would execute `cd` and then dump you into your home directory.

Instead, if we `raise SystemExit` in the `verify` we can trap a non-zero status code and stay in place in case of an error.

I don't think this has any bad side-effects as the `verify` Exception was never trapped. Though I guess we lose the traceback.