### PR TITLE
Fixes #24. Add recurse_submodules ability

### DIFF
--- a/mepo.d/command/clone/clone.py
+++ b/mepo.d/command/clone/clone.py
@@ -6,7 +6,8 @@ def run(args):
     max_namelen = len(max([comp.name for comp in allcomps], key=len))
     for comp in allcomps:
         git = GitRepository(comp.remote, comp.local)
-        git.clone()
+        recurse = comp.recurse_submodules
+        git.clone(recurse)
         if comp.sparse:
             git.sparsify(comp.sparse)
         git.checkout(comp.version.name)

--- a/mepo.d/repository/git.py
+++ b/mepo.d/repository/git.py
@@ -21,8 +21,11 @@ class GitRepository(object):
     def get_remote_url(self):
         return self.__remote
 
-    def clone(self):
-        cmd = 'git clone --quiet {} {}'.format(self.__remote, self.__local)
+    def clone(self, recurse):
+        cmd = 'git clone '
+        if recurse:
+            cmd += '--recurse-submodules '
+        cmd += '--quiet {} {}'.format(self.__remote, self.__local)
         shellcmd.run(cmd.split())
 
     def checkout(self, version):

--- a/mepo.d/state/component.py
+++ b/mepo.d/state/component.py
@@ -4,7 +4,7 @@ from utilities.version import MepoVersion
 
 class MepoComponent(object):
 
-    __slots__ = ['name', 'local', 'remote', 'version', 'develop', 'sparse']
+    __slots__ = ['name', 'local', 'remote', 'version', 'develop', 'sparse', 'recurse_submodules']
 
     def __init__(self):
         self.name = None
@@ -13,6 +13,7 @@ class MepoComponent(object):
         self.version = None
         self.develop = None
         self.sparse = None
+        self.recurse_submodules = None
 
     def __repr__(self):
         return '{} - local: {}, remote: {}, version: {}, develop:{}'.format(
@@ -34,6 +35,7 @@ class MepoComponent(object):
         self.remote = comp_details['remote']
         self.develop = comp_details.get('develop', None) # develop is optional
         self.sparse = comp_details.get('sparse', None) # sparse is optional
+        self.recurse_submodules = comp_details.get('recurse_submodules', None) # recurse_submodules is optional
         self.__set_original_version(comp_details)
         return self
 
@@ -52,4 +54,6 @@ class MepoComponent(object):
             details['develop'] = self.develop
         if self.sparse:
             details['sparse'] = self.sparse
+        if self.recurse_submodules:
+            details['recurse_submodules'] = self.recurse_submodules
         return {self.name: details}


### PR DESCRIPTION
This adds the ability to add a `recurse_submodules` line to the
`components.yaml`, e.g.:

```yaml
pfunit:
  local: ./@pfunit
  remote: git@github.com:Goddard-Fortran-Ecosystem/pFUnit.git
  tag: v4.1.5
  recurse_submodules: True
```