### PR TITLE
Fixes #33. Adds a new checkout-if-exists command

### DIFF
--- a/mepo.d/cmdline/parser.py
+++ b/mepo.d/cmdline/parser.py
@@ -21,6 +21,7 @@ class MepoArgParser(object):
         self.__status()
         self.__diff()
         self.__checkout()
+        self.__checkout_if_exists()
         self.__branch()
         self.__develop()
         self.__compare()
@@ -72,6 +73,13 @@ class MepoArgParser(object):
         checkout.add_argument('branch_name', metavar = 'branch-name')
         checkout.add_argument('comp_name', metavar = 'comp-name', nargs = '+')
         checkout.add_argument('-b', action = 'store_true', help = 'create the branch')
+
+    def __checkout_if_exists(self):
+        checkout_if_exists = self.subparsers.add_parser(
+            'checkout-if-exists',
+            description = 'Switch to branch <branch-name> in any component where it is present. ')
+        checkout_if_exists.add_argument('branch_name', metavar = 'branch-name')
+        checkout_if_exists.add_argument('--verbose', action = 'store_true', help = 'verbose')
 
     def __branch(self):
         branch = self.subparsers.add_parser('branch')

--- a/mepo.d/command/checkout-if-exists/checkout-if-exists.py
+++ b/mepo.d/command/checkout-if-exists/checkout-if-exists.py
@@ -1,0 +1,15 @@
+from state.state import MepoState
+from utilities import verify
+from repository.git import GitRepository
+
+def run(args):
+    allcomps = MepoState.read_state()
+    for comp in allcomps:
+        git = GitRepository(comp.remote, comp.local)
+        branch = args.branch_name
+        status = git.verify_branch(branch)
+
+        if status == 0:
+            if args.verbose:
+                print("Found branch [%s] in repository [%s]" % (branch, comp.name))
+            git.checkout(branch)

--- a/mepo.d/repository/git.py
+++ b/mepo.d/repository/git.py
@@ -62,6 +62,11 @@ class GitRepository(object):
         cmd = self.__git + ' branch {} {}'.format(delete, branch_name)
         shellcmd.run(cmd.split())
 
+    def verify_branch(self, branch_name):
+        cmd = self.__git + ' show-branch remotes/origin/{}'.format(branch_name)
+        status = shellcmd.run(cmd.split(),status=True)
+        return status
+
     def check_status(self):
         cmd = self.__git + ' status --porcelain=v2'
         output = shellcmd.run(cmd.split(), output=True)

--- a/mepo.d/utilities/shellcmd.py
+++ b/mepo.d/utilities/shellcmd.py
@@ -1,14 +1,18 @@
 import subprocess as sp
 
-def run(cmd, output=None):
+def run(cmd, output=None, status=None):
     result = sp.run(
         cmd,
         stdout = sp.PIPE,
         stderr = sp.PIPE,
         universal_newlines = True # result byte sequence -> string
     )
-    if result.returncode != 0:
+
+    if status:
+        return result.returncode
+    elif result.returncode != 0:
         print(result.stderr)
         result.check_returncode()
+
     if output:
         return result.stdout + result.stderr


### PR DESCRIPTION
This command is run like:
```
mepo checkout-if-exists <branch-name>
```
It then checks every repository for that branch and if it's found, it
checks it out.