### PR TITLE
Fixes #25. Allow for relative URLs in components.yaml

### DIFF
--- a/etc/mepo-completion.bash
+++ b/etc/mepo-completion.bash
@@ -6,7 +6,9 @@ _get_mepo_commands() {
     local mepo_cmd_list=""
     local mepodir=$(dirname $(which mepo))
     for mydir in $(ls -d ${mepodir}/mepo.d/command/*/); do
-        mepo_cmd_list+=" $(basename $mydir)"
+        if [[ $mydir != *"__pycache__"* ]]; then
+            mepo_cmd_list+=" $(basename $mydir)"
+        fi
     done
     echo ${mepo_cmd_list}
 }

--- a/mepo.d/repository/git.py
+++ b/mepo.d/repository/git.py
@@ -34,6 +34,7 @@ class GitRepository(object):
 
     def sparsify(self, sparse_config):
         dst = os.path.join(self.__local, '.git', 'info', 'sparse-checkout')
+        os.makedirs(os.path.dirname(dst), exist_ok=True)
         shutil.copy(sparse_config, dst)
         cmd1 = self.__git + ' config core.sparseCheckout true'
         shellcmd.run(cmd1.split())

--- a/mepo.d/state/state.py
+++ b/mepo.d/state/state.py
@@ -6,6 +6,9 @@ import pickle
 
 from config.config_file import ConfigFile
 from state.component import MepoComponent
+from utilities import shellcmd
+from pathlib import Path
+from urllib.parse import urljoin
 
 class MepoState(object):
 
@@ -56,6 +59,14 @@ class MepoState(object):
         input_components = ConfigFile(project_config_file).read_file()
         complist = list()
         for name, comp in input_components.items():
+            for key, value in comp.items():
+                if key == "remote":
+                    if comp[key].startswith('..'):
+                        rel_remote = os.path.basename(comp[key])
+                        fixture_url = get_current_remote_url()
+                        resolved_remote = urljoin(fixture_url,rel_remote)
+                        comp[key] = resolved_remote
+                        print("Resolved remote: ", resolved_remote)
             complist.append(MepoComponent().to_component(name, comp))
         cls.write_state(complist)
 
@@ -87,3 +98,7 @@ class MepoState(object):
             os.remove(state_fileptr)
         os.symlink(new_state_file, state_fileptr)
 
+def get_current_remote_url():
+    cmd = 'git remote get-url origin'
+    output = shellcmd.run(cmd.split(), output=True).strip()
+    return output

--- a/mepo.d/state/state.py
+++ b/mepo.d/state/state.py
@@ -66,7 +66,6 @@ class MepoState(object):
                         fixture_url = get_current_remote_url()
                         resolved_remote = urljoin(fixture_url,rel_remote)
                         comp[key] = resolved_remote
-                        print("Resolved remote: ", resolved_remote)
             complist.append(MepoComponent().to_component(name, comp))
         cls.write_state(complist)
 


### PR DESCRIPTION
This seems to allow the ability to use relative URLs in `components.yaml` which is useful on machines that don't have SSH keys (aka docker).

Also fix a bug with sparsify (not sure how it ever worked before) and tweak the completion file.