### PR TITLE
Fixes #44. Make mepo commit act like git commit

### DIFF
--- a/mepo.d/cmdline/parser.py
+++ b/mepo.d/cmdline/parser.py
@@ -134,7 +134,7 @@ class MepoArgParser(object):
         commit = self.subparsers.add_parser(
             'commit',
             description = 'Commit staged files in the specified components')
-        commit.add_argument('message', metavar = 'message')
+        commit.add_argument('-m', '--message', type=str, metavar = 'message', default=None)
         commit.add_argument(
             'comp_name',
             metavar = 'comp-name',

--- a/mepo.d/repository/git.py
+++ b/mepo.d/repository/git.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import subprocess
 
 from utilities import shellcmd
 from utilities import colors
@@ -173,8 +174,12 @@ class GitRepository(object):
         shellcmd.run(cmd.split())
 
     def commit_files(self, message):
-        cmd = ['git', '-C', self.__local, 'commit', '-m', message]
-        shellcmd.run(cmd)
+        if message:
+            cmd = ['git', '-C', self.__local, 'commit', '-m', message]
+            shellcmd.run(cmd)
+        else:
+            cmd = ['git', '-C', self.__local, 'commit']
+            subprocess.call(cmd)
 
     def push(self):
         cmd = self.__git + ' push -u {}'.format(self.__remote)


### PR DESCRIPTION
This seems to allow both for a no-message `mepo commit` and `mepo commit -m`

My only concern is that I have to use `subprocess.call()` to get
`$EDITOR` to spawn. Sometimes call is odd...but it seems to work!