### PR TITLE
Fixes #45. Verbose checkout-if-exists

### DIFF
--- a/mepo.d/cmdline/parser.py
+++ b/mepo.d/cmdline/parser.py
@@ -79,7 +79,7 @@ class MepoArgParser(object):
             'checkout-if-exists',
             description = 'Switch to branch <branch-name> in any component where it is present. ')
         checkout_if_exists.add_argument('branch_name', metavar = 'branch-name')
-        checkout_if_exists.add_argument('--verbose', action = 'store_true', help = 'verbose')
+        checkout_if_exists.add_argument('--quiet', action = 'store_true', help = 'Suppress found messages')
 
     def __branch(self):
         branch = self.subparsers.add_parser('branch')

--- a/mepo.d/command/checkout-if-exists/checkout-if-exists.py
+++ b/mepo.d/command/checkout-if-exists/checkout-if-exists.py
@@ -1,6 +1,7 @@
 from state.state import MepoState
 from utilities import verify
 from repository.git import GitRepository
+from utilities import colors
 
 def run(args):
     allcomps = MepoState.read_state()
@@ -10,6 +11,8 @@ def run(args):
         status = git.verify_branch(branch)
 
         if status == 0:
-            if args.verbose:
-                print("Found branch [%s] in repository [%s]" % (branch, comp.name))
+            if not args.quiet:
+                print("Checking out branch %s in %s" % 
+                        (colors.YELLOW + branch + colors.RESET, 
+                         colors.RESET + comp.name + colors.RESET))
             git.checkout(branch)


### PR DESCRIPTION
`checkout-if-exists` already had a `--verbose` flag. Now make that a `--quiet` flag and print all the times. :smile: 