### PR TITLE
Fixes #48. Open one editor for multi repo commit

### DIFF
--- a/mepo.d/command/commit/commit.py
+++ b/mepo.d/command/commit/commit.py
@@ -15,7 +15,6 @@ def run(args):
     # Pop up an editor if a message is not provided
     if not args.message:
         EDITOR = git_var('GIT_EDITOR')
-        print(EDITOR)
         initial_message = b"" # set up the file
 
         # Use delete=False to keep the file around as we send the file name to git commit -F

--- a/mepo.d/command/commit/commit.py
+++ b/mepo.d/command/commit/commit.py
@@ -39,7 +39,12 @@ def run(args):
         os.unlink(tf.name)
 
 def git_var(what):
-    "return GIT_EDITOR or GIT_PAGER, for instance"
+    '''
+    return GIT_EDITOR or GIT_PAGER, for instance
+
+    Found at https://stackoverflow.com/a/44174750/1876449
+
+    '''
     proc = subprocess.Popen(['git', 'var', what], shell=False,
         stdout=subprocess.PIPE)
     output = proc.stdout.read()

--- a/mepo.d/command/commit/commit.py
+++ b/mepo.d/command/commit/commit.py
@@ -14,7 +14,8 @@ def run(args):
 
     # Pop up an editor if a message is not provided
     if not args.message:
-        EDITOR = os.environ.get('EDITOR','vim') # Get the EDITOR
+        EDITOR = git_var('GIT_EDITOR')
+        print(EDITOR)
         initial_message = b"" # set up the file
 
         # Use delete=False to keep the file around as we send the file name to git commit -F
@@ -37,3 +38,16 @@ def run(args):
     if not args.message:
         tf.close()
         os.unlink(tf.name)
+
+def git_var(what):
+    "return GIT_EDITOR or GIT_PAGER, for instance"
+    proc = subprocess.Popen(['git', 'var', what], shell=False,
+        stdout=subprocess.PIPE)
+    output = proc.stdout.read()
+    status = proc.wait()
+    if status != 0:
+        raise Exception("git_var failed with [%]" % what)
+    output = output.rstrip(b'\n')
+    output = output.decode('utf8', errors='ignore') # or similar for py3k
+    return output
+

--- a/mepo.d/command/commit/commit.py
+++ b/mepo.d/command/commit/commit.py
@@ -2,14 +2,38 @@ from state.state import MepoState
 from utilities import verify
 from repository.git import GitRepository
 
+# Popping up an EDITOR is based on https://stackoverflow.com/a/39989442
+import os, tempfile, subprocess
+
 def run(args):
     allcomps = MepoState.read_state()
     verify.valid_components(args.comp_name, allcomps)
     comps2commit = [x for x in allcomps if x.name in args.comp_name]
+
+    tf_file = None
+
+    # Pop up an editor if a message is not provided
+    if not args.message:
+        EDITOR = os.environ.get('EDITOR','vim') # Get the EDITOR
+        initial_message = b"" # set up the file
+
+        # Use delete=False to keep the file around as we send the file name to git commit -F
+        tf = tempfile.NamedTemporaryFile(delete=False)
+        tf_file = tf.name
+        tf.write(initial_message)
+        tf.flush()
+        subprocess.call([EDITOR, tf.name])
+
     for comp in comps2commit:
         git = GitRepository(comp.remote, comp.local)
         staged_files = git.get_staged_files()
         if staged_files:
-            git.commit_files(args.message)
+            git.commit_files(args.message,tf_file)
+
         for myfile in staged_files:
             print('+ {}: {}'.format(comp.name, myfile))
+
+    # Now close and by-hand delete the temp file
+    if not args.message:
+        tf.close()
+        os.unlink(tf.name)

--- a/mepo.d/repository/git.py
+++ b/mepo.d/repository/git.py
@@ -176,13 +176,14 @@ class GitRepository(object):
         cmd = self.__git + ' reset -- {}'.format(myfile)
         shellcmd.run(cmd.split())
 
-    def commit_files(self, message):
-        if message:
+    def commit_files(self, message, tf_file=None):
+        if tf_file:
+            cmd = ['git', '-C', self.__local, 'commit', '-F', tf_file]
+        elif message:
             cmd = ['git', '-C', self.__local, 'commit', '-m', message]
-            shellcmd.run(cmd)
         else:
-            cmd = ['git', '-C', self.__local, 'commit']
-            subprocess.call(cmd)
+            raise Exception("This should not happen")
+        shellcmd.run(cmd)
 
     def push(self):
         cmd = self.__git + ' push -u {}'.format(self.__remote)


### PR DESCRIPTION
This seems to allow a single EDITOR call to have a message for multiple repos