### PR TITLE
Fixes #57. mepo-cd alone moves to root

### DIFF
--- a/etc/mepo-cd.bash
+++ b/etc/mepo-cd.bash
@@ -1,13 +1,25 @@
 function usage_ () {
-    echo "usage: mepo-cd <component>"
+    echo "usage: "
+    echo "       mepo-cd             : cd to root of mepo project"
+    echo "       mepo-cd <component> : cd to directory of <component>"
+    echo ""
+    echo "mepo-cd accepts only 0 or 1 arguments"
 }
 
 function mepo-cd () {
-    if [ "$#" -ne 1 ]; then
+    if [ "$#" -gt 1 ]; then
         usage_
         return 1
     fi
-    output=$(mepo whereis $1)
+    if [ "$1" == "-h" ]; then
+       usage_
+       return 0
+    fi
+    if [ "$#" -eq 0 ]; then
+       output=$(mepo whereis _root)
+    else
+       output=$(mepo whereis $1)
+    fi
     if [ $? -eq 0 ]; then
         cd $output
     fi

--- a/mepo
+++ b/mepo
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/local/other/python/GEOSpyD/2019.10_py3.7/2020-01-15/bin/python3
 
 import os
 import sys

--- a/mepo.d/command/whereis/whereis.py
+++ b/mepo.d/command/whereis/whereis.py
@@ -7,6 +7,8 @@ def run(args):
     allcomps = MepoState.read_state()
     if args.comp_name: # single comp name is specified, print relpath
         if args.comp_name == "_root":
+            # _root is a "hidden" allowed argument for whereis to return
+            # the root dir of the project. Mainly used by mepo-cd
             print(MepoState.get_root_dir())
         else:
             verify.valid_components([args.comp_name], allcomps)

--- a/mepo.d/command/whereis/whereis.py
+++ b/mepo.d/command/whereis/whereis.py
@@ -6,10 +6,13 @@ from utilities import verify
 def run(args):
     allcomps = MepoState.read_state()
     if args.comp_name: # single comp name is specified, print relpath
-        verify.valid_components([args.comp_name], allcomps)
-        for comp in allcomps:
-            if comp.name == args.comp_name:
-                print(_get_relative_path(comp.local))
+        if args.comp_name == "_root":
+            print(MepoState.get_root_dir())
+        else:
+            verify.valid_components([args.comp_name], allcomps)
+            for comp in allcomps:
+                if comp.name == args.comp_name:
+                    print(_get_relative_path(comp.local))
     else: # print relpaths of all comps
         max_namelen = len(max([x.name for x in allcomps], key=len))
         FMT = '{:<%s.%ss} | {:<s}' % (max_namelen, max_namelen)


### PR DESCRIPTION
This PR should allow `mepo-cd` alone to `cd` to the root of the project where 'root' is where `root/.mepo/` exists.