### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/mepo.yaml
+++ b/.github/workflows/mepo.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]
         python-version: [3.x, pypy3]
 
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }}

--- a/.github/workflows/mepo.yaml
+++ b/.github/workflows/mepo.yaml
@@ -13,6 +13,7 @@ jobs:
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}

--- a/.github/workflows/mepo.yaml
+++ b/.github/workflows/mepo.yaml
@@ -4,15 +4,18 @@ on: [push]
 
 jobs:
   build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [3.x, pypy3]
 
-    runs-on: ubuntu-latest
-
+    name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+    - uses: actions/checkout@v2
+      uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
The old GitHub actions were using v1, move to v2.

Also, build/test with Linux and macOS and Python 3.x and pypy3.

Note: I tried windows-latest as well, but it went kaboom. And as I don't have a WSL instance to play with yet, I'm removing its testing for now.