### PR TITLE
Fixes #47. Allow clone to initialize

### DIFF
--- a/mepo.d/cmdline/parser.py
+++ b/mepo.d/cmdline/parser.py
@@ -48,7 +48,13 @@ class MepoArgParser(object):
     def __clone(self):
         clone = self.subparsers.add_parser(
             'clone',
-            description = "Clone repositories. Command 'mepo init' should have already been run")
+            description = "Clone repositories.")
+        clone.add_argument(
+            'config_file',
+            metavar = 'config-file',
+            nargs = '?',
+            default = 'components.yaml',
+            help = 'Configuration file (ignored if init already called, default: %(default)s)')
 
     def __list(self):
         listcomps = self.subparsers.add_parser(

--- a/mepo.d/command/clone/clone.py
+++ b/mepo.d/command/clone/clone.py
@@ -1,8 +1,18 @@
-from state.state import MepoState
+from state.state    import MepoState, MepoStateDoesNotExistError
 from repository.git import GitRepository
+from command.init   import init as mepo_init
 
 def run(args):
-    allcomps = MepoState.read_state()
+    # This tries to read the state and if not, calls init,
+    # loops back, and reads the state
+    while True:
+        try:
+            allcomps = MepoState.read_state()
+        except MepoStateDoesNotExistError:
+            mepo_init.run(args)
+            continue
+        break
+
     max_namelen = len(max([comp.name for comp in allcomps], key=len))
     for comp in allcomps:
         git = GitRepository(comp.remote, comp.local)

--- a/mepo.d/command/init/init.py
+++ b/mepo.d/command/init/init.py
@@ -2,4 +2,4 @@ from state.state import MepoState
 
 def run(args):
     allcomps = MepoState.initialize(args.config_file)
-    print('Initialized mepo!')
+    print('Initializing mepo using {}'.format(args.config_file))

--- a/mepo.d/state/state.py
+++ b/mepo.d/state/state.py
@@ -10,6 +10,14 @@ from utilities import shellcmd
 from pathlib import Path
 from urllib.parse import urljoin
 
+class MepoStateDoesNotExistError(Exception):
+    """Raised when the mepo state does not exist"""
+    pass
+
+class MepoStateAlreadyInitializedError(Exception):
+    """Raised when the mepo state has already been initialized"""
+    pass
+
 class MepoState(object):
 
     __state_dir_name = '.mepo'
@@ -55,7 +63,7 @@ class MepoState(object):
     @classmethod
     def initialize(cls, project_config_file):
         if cls.exists():
-            raise Exception('mepo state already exists')
+            raise MepoStateAlreadyInitializedError('mepo state already exists')
         input_components = ConfigFile(project_config_file).read_file()
         complist = list()
         for name, comp in input_components.items():
@@ -72,7 +80,7 @@ class MepoState(object):
     @classmethod
     def read_state(cls):
         if not cls.exists():
-            raise Exception('mepo state does not exist')
+            raise MepoStateDoesNotExistError('mepo state does not exist')
         with open(cls.get_file(), 'rb') as fin:
             allcomps = pickle.load(fin)
         return allcomps


### PR DESCRIPTION
This change let's one do:
```
mepo clone
```
or even:
```
mepo clone <yaml-file>
```
and will initialize mepo if not already done