### PR TITLE
Fixes #73. Allow mepo clone to use a URL

### DIFF
--- a/mepo.d/cmdline/parser.py
+++ b/mepo.d/cmdline/parser.py
@@ -39,7 +39,7 @@ class MepoArgParser(object):
             'init',
             description = 'Initialize mepo based on <config-file>')
         init.add_argument(
-            'config_file',
+            '--config',
             metavar = 'config-file',
             nargs = '?',
             default = 'components.yaml',
@@ -50,7 +50,12 @@ class MepoArgParser(object):
             'clone',
             description = "Clone repositories.")
         clone.add_argument(
-            'config_file',
+            'repo_url',
+            nargs = '?',
+            default = None,
+            help = 'URL to clone')
+        clone.add_argument(
+            '--config',
             metavar = 'config-file',
             nargs = '?',
             default = 'components.yaml',

--- a/mepo.d/command/clone/clone.py
+++ b/mepo.d/command/clone/clone.py
@@ -1,14 +1,32 @@
-from state.state    import MepoState, MepoStateDoesNotExistError
+from state.state    import MepoState, StateDoesNotExistError
 from repository.git import GitRepository
 from command.init   import init as mepo_init
+from utilities      import shellcmd
+from urllib.parse import urlparse
+
+import os
+import pathlib
 
 def run(args):
+
+    if args.repo_url:
+        p = urlparse(args.repo_url)
+        last_url_node = p.path.rsplit('/')[-1]
+        url_suffix = pathlib.Path(last_url_node).suffix
+        if url_suffix == '.git':
+            git_url_directory = pathlib.Path(last_url_node).stem
+        else:
+            git_url_directory = last_url_node
+
+        local_clone(args.repo_url)
+        os.chdir(git_url_directory)
+
     # This tries to read the state and if not, calls init,
     # loops back, and reads the state
     while True:
         try:
             allcomps = MepoState.read_state()
-        except MepoStateDoesNotExistError:
+        except StateDoesNotExistError:
             mepo_init.run(args)
             continue
         break
@@ -26,3 +44,8 @@ def run(args):
 def print_clone_info(comp, name_width):
     ver_name_type = '({}) {}'.format(comp.version.type, comp.version.name)
     print('{:<{width}} | {:<s}'.format(comp.name, ver_name_type, width = name_width))
+
+def local_clone(url):
+    cmd = 'git clone '
+    cmd += '--quiet {}'.format(url)
+    shellcmd.run(cmd.split())

--- a/mepo.d/command/init/init.py
+++ b/mepo.d/command/init/init.py
@@ -1,5 +1,5 @@
 from state.state import MepoState
 
 def run(args):
-    allcomps = MepoState.initialize(args.config_file)
-    print('Initializing mepo using {}'.format(args.config_file))
+    allcomps = MepoState.initialize(args.config)
+    print('Initializing mepo using {}'.format(args.config))

--- a/mepo.d/config/config_file.py
+++ b/mepo.d/config/config_file.py
@@ -1,5 +1,7 @@
 import pathlib
 
+from state.exceptions import SuffixNotRecognizedError
+
 class ConfigFile(object):
 
     __slots__ = ['__filename', '__filetype']
@@ -11,7 +13,7 @@ class ConfigFile(object):
         if file_suffix in SUFFIX_LIST:
             self.__filetype = file_suffix[1:]
         else:
-            raise RuntimeError('suffix {} not supported'.format(file_suffix))
+            raise SuffixNotRecognizedError('suffix {} not supported'.format(file_suffix))
 
     def read_file(self):
         '''Call read_yaml, read_json etc. using dispatch pattern'''

--- a/mepo.d/repository/git.py
+++ b/mepo.d/repository/git.py
@@ -4,6 +4,7 @@ import subprocess
 
 from utilities import shellcmd
 from utilities import colors
+from urllib.parse import urljoin
 
 class GitRepository(object):
     """
@@ -26,7 +27,13 @@ class GitRepository(object):
         cmd = 'git clone '
         if recurse:
             cmd += '--recurse-submodules '
-        cmd += '--quiet {} {}'.format(self.__remote, self.__local)
+        if self.__remote.startswith('..'):
+            rel_remote = os.path.basename(self.__remote)
+            fixture_url = get_current_remote_url()
+            remote = urljoin(fixture_url,rel_remote)
+        else:
+            remote = self.__remote
+        cmd += '--quiet {} {}'.format(remote, self.__local)
         shellcmd.run(cmd.split())
 
     def checkout(self, version):
@@ -233,3 +240,8 @@ class GitRepository(object):
                 name = tmp
                 tYpe = 'b'
         return (name, tYpe, detached)
+
+def get_current_remote_url():
+    cmd = 'git remote get-url origin'
+    output = shellcmd.run(cmd.split(), output=True).strip()
+    return output

--- a/mepo.d/state/exceptions.py
+++ b/mepo.d/state/exceptions.py
@@ -1,0 +1,15 @@
+class StateDoesNotExistError(Exception):
+    """Raised when the mepo state does not exist"""
+    pass
+
+class StateAlreadyInitializedError(Exception):
+    """Raised when the mepo state has already been initialized"""
+    pass
+
+class ConfigFileNotFoundError(FileNotFoundError):
+    """Raised when the config file is not found"""
+    pass
+
+class SuffixNotRecognizedError(RuntimeError):
+    """Raised when the config suffix is not recognized"""
+    pass

--- a/mepo.d/utest/test_mepo_commands.py
+++ b/mepo.d/utest/test_mepo_commands.py
@@ -39,10 +39,11 @@ class TestMepoCommands(unittest.TestCase):
             shutil.rmtree(cls.fixture_dir)
         cls.__checkout_fixture()
         cls.__copy_config_file()
-        args.config_file = 'components.yaml'
+        args.config = 'components.yaml'
         os.chdir(cls.fixture_dir)
         mepo_init.run(args)
         args.config = None
+        args.repo_url = None
         mepo_clone.run(args)
 
     def setUp(self):


### PR DESCRIPTION
This PR is to allow `mepo` to do:
```
mepo clone URL
```
and have it do the `git clone`, then `chdir`, then run `mepo init` and then `mepo clone` all in one shot. But there are some minor changes and caveats to allow this:

* `mepo init` and `mepo clone` have a new `--config` option that will be used to specify a different `components.yaml` file. Before it was the only option, but since a URL can be passed to `clone` without a `--option`, configs lost.
* `mepo clone URL` is fragile. It seems to work with all variants of https and ssh but issues are possible.

Example:
```
❯ mepo clone git@github.com:GEOS-ESM/GEOSgcm.git
Initializing mepo using components.yaml
env                    | (t) v2.1.5
cmake                  | (t) v3.0.6
ecbuild                | (t) geos/v1.0.5
NCEP_Shared            | (t) v1.0.0
GMAO_Shared            | (t) v1.1.4
GSW-Fortran            | (b) origin/develop
MAPL                   | (t) v2.1.4
FMS                    | (t) geos/2019.01.01
GEOSgcm_GridComp       | (t) v1.8.6
FVdycoreCubed_GridComp | (t) v1.1.1
fvdycore               | (t) geos/v1.1.0
GEOSchem_GridComp      | (t) v1.3.5
mom                    | (t) geos/v1.0.1
GEOSgcm_App            | (t) v1.3.4
UMD_Etc                | (t) v1.0.3
CPLFCST_Etc            | (t) v1.0.1
```