### PR TITLE
Fixes #75. Handle git hashes better

### DIFF
--- a/mepo.d/repository/git.py
+++ b/mepo.d/repository/git.py
@@ -239,6 +239,12 @@ class GitRepository(object):
             else:
                 name = tmp
                 tYpe = 'b'
+        elif output.startswith('HEAD'): # Assume hash
+            cmd = self.__git + ' rev-parse --short HEAD'
+            hash_out = shellcmd.run(cmd.split(), output=True)
+            detached = True
+            name = hash_out.rstrip()
+            tYpe = 'h'
         return (name, tYpe, detached)
 
 def get_current_remote_url():

--- a/mepo.d/state/component.py
+++ b/mepo.d/state/component.py
@@ -24,6 +24,10 @@ class MepoComponent(object):
             # SPECIAL HANDLING of 'detached head' branches
             ver_name = 'origin/' + comp_details['branch']
             ver_type = 'b'
+        elif comp_details.get('hash', None):
+            # Hashes don't have to exist
+            ver_name = comp_details['hash'][:7]
+            ver_type = 'h'
         else:
             ver_name = comp_details['tag'] # 'tag' key has to exist
             ver_type = 't'


### PR DESCRIPTION
- Makes `mepo status` etc. not crash with non-tag hashes
- Allows one to specify `hash: a12345b` say in `components.yaml`