### PR TITLE
Fixes #8. Add basic mepo stash subcommands

### DIFF
--- a/mepo.d/cmdline/parser.py
+++ b/mepo.d/cmdline/parser.py
@@ -1,6 +1,7 @@
 import argparse
 
 from cmdline.branch_parser import MepoBranchArgParser
+from cmdline.stash_parser  import MepoStashArgParser
 
 class MepoArgParser(object):
 
@@ -24,6 +25,7 @@ class MepoArgParser(object):
         self.__checkout()
         self.__checkout_if_exists()
         self.__branch()
+        self.__stash()
         self.__develop()
         self.__compare()
         self.__whereis()
@@ -107,6 +109,10 @@ class MepoArgParser(object):
     def __branch(self):
         branch = self.subparsers.add_parser('branch')
         MepoBranchArgParser(branch)
+
+    def __stash(self):
+        stash = self.subparsers.add_parser('stash')
+        MepoStashArgParser(stash)
 
     def __develop(self):
         develop = self.subparsers.add_parser(

--- a/mepo.d/cmdline/parser.py
+++ b/mepo.d/cmdline/parser.py
@@ -111,7 +111,9 @@ class MepoArgParser(object):
         MepoBranchArgParser(branch)
 
     def __stash(self):
-        stash = self.subparsers.add_parser('stash')
+        stash = self.subparsers.add_parser(
+                'stash',
+                description = "Runs stash commands.")
         MepoStashArgParser(stash)
 
     def __develop(self):

--- a/mepo.d/cmdline/stash_parser.py
+++ b/mepo.d/cmdline/stash_parser.py
@@ -7,10 +7,27 @@ class MepoStashArgParser(object):
         self.stash.title = 'mepo stash sub-commands'
         self.stash.dest = 'mepo_stash_cmd'
         self.stash.required = True
+        self.__push()
         self.__list()
         self.__pop()
         self.__apply()
         
+    def __push(self):
+        stpush = self.stash.add_parser(
+            'push',
+            description = 'Push (create) stash in component <comp-name>')
+        stpush.add_argument(
+                '-m', '--message', 
+                type=str, 
+                metavar = 'message', 
+                default=None,
+                help = 'Message for the stash')
+        stpush.add_argument(
+            'comp_name',
+            metavar = 'comp-name',
+            nargs = '+',
+            help = 'Component to push stash in')
+
     def __list(self):
         stlist = self.stash.add_parser(
             'list',

--- a/mepo.d/cmdline/stash_parser.py
+++ b/mepo.d/cmdline/stash_parser.py
@@ -1,0 +1,37 @@
+import argparse
+
+class MepoStashArgParser(object):
+
+    def __init__(self, stash):
+        self.stash = stash.add_subparsers()
+        self.stash.title = 'mepo stash sub-commands'
+        self.stash.dest = 'mepo_stash_cmd'
+        self.stash.required = True
+        self.__list()
+        self.__pop()
+        self.__apply()
+        
+    def __list(self):
+        stlist = self.stash.add_parser(
+            'list',
+            description = 'List local stashes of all components')
+
+    def __pop(self):
+        stpop = self.stash.add_parser(
+            'pop',
+            description = 'Pop stash in component <comp-name>')
+        stpop.add_argument(
+            'comp_name',
+            metavar = 'comp-name',
+            nargs = '+',
+            help = 'Component to pop stash in')
+
+    def __apply(self):
+        stapply = self.stash.add_parser(
+            'apply',
+            description = 'apply stash in component <comp-name>')
+        stapply.add_argument(
+            'comp_name',
+            metavar = 'comp-name',
+            nargs = '+',
+            help = 'Component to apply stash in')

--- a/mepo.d/command/stash/stapply/stapply.py
+++ b/mepo.d/command/stash/stapply/stapply.py
@@ -1,0 +1,12 @@
+from state.state import MepoState
+from utilities import verify
+from repository.git import GitRepository
+
+def run(args):
+    allcomps = MepoState.read_state()
+    verify.valid_components(args.comp_name, allcomps)
+    comps2appst = [x for x in allcomps if x.name in args.comp_name]
+    for comp in comps2appst:
+        git = GitRepository(comp.remote, comp.local)
+        git.apply_stash()
+        #print('+ {}'.format(comp.name))

--- a/mepo.d/command/stash/stash.py
+++ b/mepo.d/command/stash/stash.py
@@ -1,0 +1,16 @@
+import subprocess as sp
+
+from state.state import MepoState
+
+from command.stash.stlist  import stlist
+from command.stash.stpop   import stpop
+from command.stash.stapply import stapply
+
+def run(args):
+    d = {
+        'list':  stlist,
+        'pop':   stpop,
+        'apply': stapply,
+    }
+    print(args.mepo_stash_cmd)
+    d[args.mepo_stash_cmd].run(args)

--- a/mepo.d/command/stash/stash.py
+++ b/mepo.d/command/stash/stash.py
@@ -5,12 +5,13 @@ from state.state import MepoState
 from command.stash.stlist  import stlist
 from command.stash.stpop   import stpop
 from command.stash.stapply import stapply
+from command.stash.stpush  import stpush
 
 def run(args):
     d = {
         'list':  stlist,
         'pop':   stpop,
         'apply': stapply,
+        'push':  stpush,
     }
-    print(args.mepo_stash_cmd)
     d[args.mepo_stash_cmd].run(args)

--- a/mepo.d/command/stash/stlist/stlist.py
+++ b/mepo.d/command/stash/stlist/stlist.py
@@ -1,0 +1,13 @@
+from state.state import MepoState
+from repository.git import GitRepository
+
+def run(args):
+    allcomps = MepoState.read_state()
+    max_namelen = len(max([x.name for x in allcomps], key=len))
+    FMT = '{:<%s.%ss} | {:<s}' % (max_namelen, max_namelen)
+    for comp in allcomps:
+        git = GitRepository(comp.remote, comp.local)
+        output = git.list_stash().rstrip().split('\n')
+        print(FMT.format(comp.name, output[0]))
+        for line in output[1:]:
+            print(FMT.format('', line))

--- a/mepo.d/command/stash/stpop/stpop.py
+++ b/mepo.d/command/stash/stpop/stpop.py
@@ -1,0 +1,12 @@
+from state.state import MepoState
+from utilities import verify
+from repository.git import GitRepository
+
+def run(args):
+    allcomps = MepoState.read_state()
+    verify.valid_components(args.comp_name, allcomps)
+    comps2popst = [x for x in allcomps if x.name in args.comp_name]
+    for comp in comps2popst:
+        git = GitRepository(comp.remote, comp.local)
+        git.pop_stash()
+        #print('+ {}'.format(comp.name))

--- a/mepo.d/command/stash/stpush/stpush.py
+++ b/mepo.d/command/stash/stpush/stpush.py
@@ -1,0 +1,12 @@
+from state.state import MepoState
+from utilities import verify
+from repository.git import GitRepository
+
+def run(args):
+    allcomps = MepoState.read_state()
+    verify.valid_components(args.comp_name, allcomps)
+    comps2pushst = [x for x in allcomps if x.name in args.comp_name]
+    for comp in comps2pushst:
+        git = GitRepository(comp.remote, comp.local)
+        git.push_stash(args.message)
+        #print('+ {}'.format(comp.name))

--- a/mepo.d/repository/git.py
+++ b/mepo.d/repository/git.py
@@ -67,6 +67,12 @@ class GitRepository(object):
         cmd = self.__git + ' stash apply'
         return shellcmd.run(cmd.split(), output=True)
 
+    def push_stash(self, message):
+        cmd = self.__git + ' stash push'
+        if message:
+            cmd += ' -m {}'.format(message)
+        return shellcmd.run(cmd.split(), output=True)
+
     def run_diff(self, args=None):
         cmd = self.__git + ' diff --color'
         if args.name_only:

--- a/mepo.d/repository/git.py
+++ b/mepo.d/repository/git.py
@@ -55,6 +55,18 @@ class GitRepository(object):
             cmd += ' -a'
         return shellcmd.run(cmd.split(), output=True)
 
+    def list_stash(self):
+        cmd = self.__git + ' stash list'
+        return shellcmd.run(cmd.split(), output=True)
+
+    def pop_stash(self):
+        cmd = self.__git + ' stash pop'
+        return shellcmd.run(cmd.split(), output=True)
+
+    def apply_stash(self):
+        cmd = self.__git + ' stash apply'
+        return shellcmd.run(cmd.split(), output=True)
+
     def run_diff(self, args=None):
         cmd = self.__git + ' diff --color'
         if args.name_only:


### PR DESCRIPTION
This PR will add four subcommands under `mepo stash`:
* `push <repo>`
* `list`
* `apply <repo>`
* `pop <repo>`

It's not perfect as you can't pass in a stash reference say, but it's a first start.