### PR TITLE
Fixes #86. Add clone branch of URL

### DIFF
--- a/mepo.d/cmdline/parser.py
+++ b/mepo.d/cmdline/parser.py
@@ -57,6 +57,12 @@ class MepoArgParser(object):
             default = None,
             help = 'URL to clone')
         clone.add_argument(
+            '--branch','-b',
+            metavar = 'name',
+            nargs = '?',
+            default = None,
+            help = 'Branch/tag of URL to initially clone (NOTE: Only useful with cloning url with mepo clone)')
+        clone.add_argument(
             '--config',
             metavar = 'config-file',
             nargs = '?',

--- a/mepo.d/command/clone/clone.py
+++ b/mepo.d/command/clone/clone.py
@@ -9,6 +9,11 @@ import pathlib
 
 def run(args):
 
+    # This protects against someone using branch without a URL
+    # as I can't figure out how to make argparse have dependent args
+    if args.branch and not args.repo_url:
+        raise RuntimeError("The branch argument can only be used with a URL")
+
     if args.repo_url:
         p = urlparse(args.repo_url)
         last_url_node = p.path.rsplit('/')[-1]
@@ -18,7 +23,7 @@ def run(args):
         else:
             git_url_directory = last_url_node
 
-        local_clone(args.repo_url)
+        local_clone(args.repo_url,args.branch)
         os.chdir(git_url_directory)
 
     # This tries to read the state and if not, calls init,
@@ -45,7 +50,9 @@ def print_clone_info(comp, name_width):
     ver_name_type = '({}) {}'.format(comp.version.type, comp.version.name)
     print('{:<{width}} | {:<s}'.format(comp.name, ver_name_type, width = name_width))
 
-def local_clone(url):
+def local_clone(url,branch=None):
     cmd = 'git clone '
+    if branch:
+        cmd += '--branch {} '.format(branch)
     cmd += '--quiet {}'.format(url)
     shellcmd.run(cmd.split())


### PR DESCRIPTION
With this change you can do:
```
mepo clone -b tag URL
```
instead of:
```
mepo clone URL
cd 
git checkout tag
```