### PR TITLE
Fixes #86. Add clone branch of URL and directory

### DIFF
--- a/mepo.d/cmdline/parser.py
+++ b/mepo.d/cmdline/parser.py
@@ -53,15 +53,21 @@ class MepoArgParser(object):
             description = "Clone repositories.")
         clone.add_argument(
             'repo_url',
+            metavar = 'URL',
             nargs = '?',
             default = None,
             help = 'URL to clone')
+        clone.add_argument(
+            'directory',
+            nargs = '?',
+            default = None,
+            help = "Directory to clone into (Only allowed with URL!)")
         clone.add_argument(
             '--branch','-b',
             metavar = 'name',
             nargs = '?',
             default = None,
-            help = 'Branch/tag of URL to initially clone (NOTE: Only useful with cloning url with mepo clone)')
+            help = 'Branch/tag of URL to initially clone (Only allowed with URL!)')
         clone.add_argument(
             '--config',
             metavar = 'config-file',

--- a/mepo.d/cmdline/parser.py
+++ b/mepo.d/cmdline/parser.py
@@ -57,6 +57,12 @@ class MepoArgParser(object):
             default = None,
             help = 'URL to clone')
         clone.add_argument(
+            '--branch','-b',
+            metavar = 'name',
+            nargs = '?',
+            default = None,
+            help = 'Branch/tag of URL to initially clone (NOTE: Only useful with cloning url with mepo clone)')
+        clone.add_argument(
             '--config',
             metavar = 'config-file',
             nargs = '?',

--- a/mepo.d/command/clone/clone.py
+++ b/mepo.d/command/clone/clone.py
@@ -9,6 +9,11 @@ import pathlib
 
 def run(args):
 
+    # This protects against someone using branch without a URL
+    # as I can't figure out how to make argparse have dependent args
+    if args.branch and not args.repo_url:
+        raise RuntimeError("The branch argument can only be used with a URL")
+
     if args.repo_url:
         p = urlparse(args.repo_url)
         last_url_node = p.path.rsplit('/')[-1]
@@ -18,7 +23,7 @@ def run(args):
         else:
             git_url_directory = last_url_node
 
-        local_clone(args.repo_url)
+        local_clone(args.repo_url,args.branch)
         os.chdir(git_url_directory)
 
     # This tries to read the state and if not, calls init,
@@ -45,7 +50,9 @@ def print_clone_info(comp, name_width):
     ver_name_type = '({}) {}'.format(comp.version.type, comp.version.name)
     print('{:<{width}} | {:<s}'.format(comp.name, ver_name_type, width = name_width))
 
-def local_clone(url):
+def local_clone(url,branch=None):
     cmd = 'git clone '
+    if branch:
+        cmd += '--branch {} '.format(branch)
     cmd += '--quiet {}'.format(url)
     shellcmd.run(cmd.split())

--- a/mepo.d/command/clone/clone.py
+++ b/mepo.d/command/clone/clone.py
@@ -10,7 +10,6 @@ import pathlib
 def run(args):
 
     # This protects against someone using branch without a URL
-    # as I can't figure out how to make argparse have dependent args
     if args.branch and not args.repo_url:
         raise RuntimeError("The branch argument can only be used with a URL")
 
@@ -18,13 +17,17 @@ def run(args):
         p = urlparse(args.repo_url)
         last_url_node = p.path.rsplit('/')[-1]
         url_suffix = pathlib.Path(last_url_node).suffix
-        if url_suffix == '.git':
-            git_url_directory = pathlib.Path(last_url_node).stem
+        if args.directory:
+            local_clone(args.repo_url,args.branch,args.directory)
+            os.chdir(args.directory)
         else:
-            git_url_directory = last_url_node
+            if url_suffix == '.git':
+                git_url_directory = pathlib.Path(last_url_node).stem
+            else:
+                git_url_directory = last_url_node
 
-        local_clone(args.repo_url,args.branch)
-        os.chdir(git_url_directory)
+            local_clone(args.repo_url,args.branch)
+            os.chdir(git_url_directory)
 
     # This tries to read the state and if not, calls init,
     # loops back, and reads the state
@@ -50,9 +53,11 @@ def print_clone_info(comp, name_width):
     ver_name_type = '({}) {}'.format(comp.version.type, comp.version.name)
     print('{:<{width}} | {:<s}'.format(comp.name, ver_name_type, width = name_width))
 
-def local_clone(url,branch=None):
+def local_clone(url,branch=None,directory=None):
     cmd = 'git clone '
     if branch:
         cmd += '--branch {} '.format(branch)
     cmd += '--quiet {}'.format(url)
+    if directory:
+        cmd += ' {}'.format(directory)
     shellcmd.run(cmd.split())

--- a/mepo.d/utest/test_mepo_commands.py
+++ b/mepo.d/utest/test_mepo_commands.py
@@ -44,6 +44,8 @@ class TestMepoCommands(unittest.TestCase):
         mepo_init.run(args)
         args.config = None
         args.repo_url = None
+        args.branch = None
+        args.directory = None
         mepo_clone.run(args)
 
     def setUp(self):


### PR DESCRIPTION
With this PR, you can do:
```
mepo clone -b tag URL
```
which is like:
```
git clone URL
cd 
git checkout tag
mepo init && mepo clone
```

ETA: Also added ability to do:
```
mepo clone URL directory
```
and even:
```
mepo clone -b tag URL directory
```
