### PR TITLE
Fixes #70. Add mepo pull, pull-all, fetch-all

### DIFF
--- a/mepo
+++ b/mepo
@@ -12,10 +12,6 @@ if sys.version_info < (3, 6, 0):
 MEPO_D = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'mepo.d')
 sys.path.insert(0, MEPO_D)
 
-# Call top level function
-from main import main
-try:
+if __name__ == '__main__':
+    from main import main
     main()
-except Exception as e:
-    traceback.print_exc()
-    sys.exit(1)

--- a/mepo.d/cmdline/parser.py
+++ b/mepo.d/cmdline/parser.py
@@ -22,11 +22,14 @@ class MepoArgParser(object):
         self.__status()
         self.__diff()
         self.__fetch()
+        self.__fetch_all()
         self.__checkout()
         self.__checkout_if_exists()
         self.__branch()
         self.__stash()
         self.__develop()
+        self.__pull()
+        self.__pull_all()
         self.__compare()
         self.__whereis()
         self.__stage()
@@ -118,6 +121,15 @@ class MepoArgParser(object):
         fetch.add_argument('--prune','-p', action = 'store_true', help = 'Prune remote branches.')
         fetch.add_argument('--tags','-t', action = 'store_true', help = 'Fetch tags.')
 
+    def __fetch_all(self):
+        fetch_all = self.subparsers.add_parser(
+            'fetch-all',
+            description = 'Download objects and refs from all components. '
+            'Specifying --all causes all remotes to be fetched.')
+        fetch_all.add_argument('--all', action = 'store_true', help = 'Fetch all remotes.')
+        fetch_all.add_argument('--prune','-p', action = 'store_true', help = 'Prune remote branches.')
+        fetch_all.add_argument('--tags','-t', action = 'store_true', help = 'Fetch tags.')
+
     def __branch(self):
         branch = self.subparsers.add_parser('branch')
         MepoBranchArgParser(branch)
@@ -133,7 +145,18 @@ class MepoArgParser(object):
             'develop',
             description = "Checkout current version of 'develop' branches of specified components")
         develop.add_argument('comp_name', metavar = 'comp-name', nargs = '+', default = None)
-        
+
+    def __pull(self):
+        pull = self.subparsers.add_parser(
+            'pull',
+            description = "Pull branches of specified components")
+        pull.add_argument('comp_name', metavar = 'comp-name', nargs = '+', default = None)
+
+    def __pull_all(self):
+        pull_all = self.subparsers.add_parser(
+            'pull-all',
+            description = "Pull branches of all components (only those in non-detached HEAD state)")
+
     def __compare(self):
         compare = self.subparsers.add_parser(
             'compare',

--- a/mepo.d/command/fetch-all/fetch-all.py
+++ b/mepo.d/command/fetch-all/fetch-all.py
@@ -1,0 +1,11 @@
+from state.state import MepoState
+from repository.git import GitRepository
+from utilities import colors
+
+def run(args):
+    allcomps = MepoState.read_state()
+    for comp in allcomps:
+        git = GitRepository(comp.remote, comp.local)
+        print("Fetching %s" %
+                 colors.YELLOW + comp.name + colors.RESET)
+        git.fetch(args)

--- a/mepo.d/command/pull-all/pull-all.py
+++ b/mepo.d/command/pull-all/pull-all.py
@@ -1,0 +1,22 @@
+from state.state import MepoState
+from repository.git import GitRepository
+from state.component import MepoVersion
+from utilities import colors
+from pprint import pprint
+
+def run(args):
+    allcomps = MepoState.read_state()
+    detached_comps=[]
+    for comp in allcomps:
+        git = GitRepository(comp.remote, comp.local)
+        name, tYpe, detached = MepoVersion(*git.get_version())
+        if detached:
+            detached_comps.append(comp.name)
+        else:
+            print("Pulling branch %s in %s " %
+                    (colors.YELLOW + name + colors.RESET,
+                     colors.RESET + comp.name + colors.RESET))
+            git.pull()
+    if len(detached_comps) > 0:
+        print("The following repos were not pulled (detached HEAD): %s" % (', '.join(map(str, detached_comps))))
+

--- a/mepo.d/command/pull/pull.py
+++ b/mepo.d/command/pull/pull.py
@@ -1,0 +1,16 @@
+from state.state import MepoState
+from utilities import verify
+from repository.git import GitRepository
+from state.component import MepoVersion
+
+def run(args):
+    allcomps = MepoState.read_state()
+    verify.valid_components(args.comp_name, allcomps)
+    comps2dev = [x for x in allcomps if x.name in args.comp_name]
+    for comp in comps2dev:
+        git = GitRepository(comp.remote, comp.local)
+        is_detached = MepoVersion(*git.get_version()).detached
+        if is_detached:
+            raise Exception('{} has detached head! Cannot stage.'.format(comp.name))
+        else:
+            git.pull()


### PR DESCRIPTION
This PR adds (per request of @sdrabenh):

- `mepo pull`
- `mepo pull-all`
- `mepo fetch-all`

Note that since you can't `git pull` on a detached HEAD state, the `pull-all` will only pull on real branches. The others will spit out as a print:
```
❯ mepo pull-all
Pulling branch throw-away in ESMA_env
The following repos were not pulled (detached HEAD): ESMA_cmake, ecbuild
```

Also fixes the `mepo` file as, on Darwin, things went kablooey recently with Python 3.8