### PR TITLE
Add revert command

### DIFF
--- a/mepo.d/cmdline/parser.py
+++ b/mepo.d/cmdline/parser.py
@@ -20,6 +20,7 @@ class MepoArgParser(object):
         self.__clone()
         self.__list()
         self.__status()
+        self.__revert()
         self.__diff()
         self.__fetch()
         self.__fetch_all()
@@ -87,6 +88,11 @@ class MepoArgParser(object):
         status = self.subparsers.add_parser(
             'status',
             description = 'Check current status of all components')
+
+    def __revert(self):
+        revert = self.subparsers.add_parser(
+            'revert',
+            description = 'Revert all components to last state.')
 
     def __diff(self):
         diff = self.subparsers.add_parser(

--- a/mepo.d/command/revert/revert.py
+++ b/mepo.d/command/revert/revert.py
@@ -1,0 +1,29 @@
+import sys
+import time
+import multiprocessing as mp
+
+from state.state import MepoState
+from repository.git import GitRepository
+from utilities.version import version_to_string
+from utilities import colors
+
+def run(args):
+    print('Checking status...'); sys.stdout.flush()
+    allcomps = MepoState.read_state()
+    pool = mp.Pool()
+    result = pool.map(check_component_status, allcomps)
+    revert_branches(allcomps, result)
+
+def check_component_status(comp):
+    git = GitRepository(comp.remote, comp.local)
+    curr_ver = version_to_string(git.get_version())
+    return (curr_ver, git.check_status())
+
+def revert_branches(allcomps, result):
+    for index, comp in enumerate(allcomps):
+        git = GitRepository(comp.remote, comp.local)
+        current_version = result[index][0].split(' ')[1]
+        orig_version = comp.version.name
+        if current_version != orig_version:
+            print(colors.YELLOW + "Reverting " + colors.RESET + "{} to {}".format(comp.name, colors.GREEN + orig_version + colors.RESET))
+            git.checkout(comp.version.name)


### PR DESCRIPTION
With this new `mepo revert` command, you should be able to revert a checkout to what the original state was. This was a request/idea inspired by @yvikhlya:
```
❯ mepo compare
Repo       | Original             | Current
---------- | -------------------- | -------
ESMA_env   | (t) v2.1.6 (DH)      | (b) feature/mathomp4/intel1912
ESMA_cmake | (t) v3.1.2 (DH)      | (t) v3.1.2 (DH)
ecbuild    | (t) geos/v1.0.5 (DH) | (t) geos/v1.0.5 (DH)

❯ mepo revert
Checking status...
Reverting ESMA_env to v2.1.6

❯ mepo compare
Repo       | Original             | Current
---------- | -------------------- | -------
ESMA_env   | (t) v2.1.6 (DH)      | (t) v2.1.6 (DH)
ESMA_cmake | (t) v3.1.2 (DH)      | (t) v3.1.2 (DH)
ecbuild    | (t) geos/v1.0.5 (DH) | (t) geos/v1.0.5 (DH)
```