### PR TITLE
Change revert to restore-state

### DIFF
--- a/mepo.d/cmdline/parser.py
+++ b/mepo.d/cmdline/parser.py
@@ -20,7 +20,7 @@ class MepoArgParser(object):
         self.__clone()
         self.__list()
         self.__status()
-        self.__revert()
+        self.__restore_state()
         self.__diff()
         self.__fetch()
         self.__fetch_all()
@@ -89,10 +89,10 @@ class MepoArgParser(object):
             'status',
             description = 'Check current status of all components')
 
-    def __revert(self):
-        revert = self.subparsers.add_parser(
-            'revert',
-            description = 'Revert all components to last state.')
+    def __restore_state(self):
+        restore_state = self.subparsers.add_parser(
+            'restore-state',
+            description = 'Restores all components to the last saved state.')
 
     def __diff(self):
         diff = self.subparsers.add_parser(

--- a/mepo.d/command/restore-state/restore-state.py
+++ b/mepo.d/command/restore-state/restore-state.py
@@ -12,18 +12,18 @@ def run(args):
     allcomps = MepoState.read_state()
     pool = mp.Pool()
     result = pool.map(check_component_status, allcomps)
-    revert_branches(allcomps, result)
+    restore_state(allcomps, result)
 
 def check_component_status(comp):
     git = GitRepository(comp.remote, comp.local)
     curr_ver = version_to_string(git.get_version())
     return (curr_ver, git.check_status())
 
-def revert_branches(allcomps, result):
+def restore_state(allcomps, result):
     for index, comp in enumerate(allcomps):
         git = GitRepository(comp.remote, comp.local)
         current_version = result[index][0].split(' ')[1]
         orig_version = comp.version.name
         if current_version != orig_version:
-            print(colors.YELLOW + "Reverting " + colors.RESET + "{} to {}".format(comp.name, colors.GREEN + orig_version + colors.RESET))
+            print(colors.YELLOW + "Restoring " + colors.RESET + "{} to {} from {}.".format(comp.name, colors.GREEN + orig_version + colors.RESET, colors.RED + current_version + colors.RESET))
             git.checkout(comp.version.name)


### PR DESCRIPTION
It was remembered that `mepo` commands with the same name as a `git` command usually try to act the same. As there is already a `git revert` command, a `mepo revert` would have to have similar functionality. It doesn't.

So we rename `mepo revert` to `mepo restore-state`.