### PR TITLE
Add ability to specify a specific branch for listing

### DIFF
--- a/mepo.d/cmdline/branch_parser.py
+++ b/mepo.d/cmdline/branch_parser.py
@@ -14,11 +14,17 @@ class MepoBranchArgParser(object):
     def __list(self):
         brlist = self.branch_subparsers.add_parser(
             'list',
-            description = 'List local branches of all components')
+            description = 'List local branches.'
+            'If no component is specified, runs over all components')
         brlist.add_argument(
             '-a', '--all',
             action = 'store_true',
-            help = 'list all (local+remote) branches of all components')
+            help = 'list all (local+remote) branches')
+        brlist.add_argument(
+            'comp_name',
+            metavar = 'comp-name',
+            nargs = '*',
+            help = 'Component to list branches in')
 
     def __create(self):
         create = self.branch_subparsers.add_parser(

--- a/mepo.d/command/branch/brlist/brlist.py
+++ b/mepo.d/command/branch/brlist/brlist.py
@@ -1,13 +1,22 @@
 from state.state import MepoState
+from utilities import verify
 from repository.git import GitRepository
 
 def run(args):
     allcomps = MepoState.read_state()
-    max_namelen = len(max([x.name for x in allcomps], key=len))
+    comps2list = _get_comps_to_list(args.comp_name, allcomps)
+    max_namelen = len(max([x.name for x in comps2list], key=len))
     FMT = '{:<%s.%ss} | {:<s}' % (max_namelen, max_namelen)
-    for comp in allcomps:
+    for comp in comps2list:
         git = GitRepository(comp.remote, comp.local)
         output = git.list_branch(args.all).rstrip().split('\n')
         print(FMT.format(comp.name, output[0]))
         for line in output[1:]:
             print(FMT.format('', line))
+
+def _get_comps_to_list(specified_comps, allcomps):
+    comps_to_list = allcomps
+    if specified_comps:
+        verify.valid_components(specified_comps, allcomps)
+        comps_to_list = [x for x in allcomps if x.name in specified_comps]
+    return comps_to_list


### PR DESCRIPTION
This adds the ability to do:
```
mepo branch list -a <component>
```
Before, `mepo branch list -a` did *all* components, and if there are a lot of branches, the list is long!