### PR TITLE
Adds a dry-run option for checkout-if-exists

### DIFF
--- a/mepo.d/cmdline/parser.py
+++ b/mepo.d/cmdline/parser.py
@@ -126,6 +126,7 @@ class MepoArgParser(object):
             description = 'Switch to branch <branch-name> in any component where it is present. ')
         checkout_if_exists.add_argument('branch_name', metavar = 'branch-name')
         checkout_if_exists.add_argument('--quiet', action = 'store_true', help = 'Suppress found messages')
+        checkout_if_exists.add_argument('--dry-run','-n', action = 'store_true', help = 'Dry-run only (lists repos where branch exists)')
 
     def __fetch(self):
         fetch = self.subparsers.add_parser(

--- a/mepo.d/command/checkout-if-exists/checkout-if-exists.py
+++ b/mepo.d/command/checkout-if-exists/checkout-if-exists.py
@@ -11,8 +11,13 @@ def run(args):
         status = git.verify_branch(branch)
 
         if status == 0:
-            if not args.quiet:
-                print("Checking out branch %s in %s" % 
-                        (colors.YELLOW + branch + colors.RESET, 
+            if args.dry_run:
+                print("Branch %s exists in %s" %
+                        (colors.YELLOW + branch + colors.RESET,
                          colors.RESET + comp.name + colors.RESET))
-            git.checkout(branch)
+            else:
+                if not args.quiet:
+                    print("Checking out branch %s in %s" %
+                            (colors.YELLOW + branch + colors.RESET,
+                            colors.RESET + comp.name + colors.RESET))
+                git.checkout(branch)


### PR DESCRIPTION
Per a request by @sdrabenh, add a `--dry-run` (also `-n`) to `checkout-if-exists` that lists where branches exist but doesn't checkout:
```
❯ mepo checkout-if-exists -n feature/mathomp4/mkl-is-optional
Branch feature/mathomp4/mkl-is-optional exists in cmake
Branch feature/mathomp4/mkl-is-optional exists in NCEP_Shared
Branch feature/mathomp4/mkl-is-optional exists in GEOSgcm_GridComp
```