### PR TITLE
Add ability to save hashes and tags to yaml

### DIFF
--- a/mepo.d/command/save/save.py
+++ b/mepo.d/command/save/save.py
@@ -3,6 +3,8 @@ from state.component import MepoVersion
 from repository.git import GitRepository
 from config.config_file import ConfigFile
 
+import os
+
 def run(args):
     allcomps = MepoState.read_state()
     for comp in allcomps:
@@ -14,27 +16,34 @@ def run(args):
     relpath_start = MepoState.get_root_dir()
     for comp in allcomps:
         complist.update(comp.to_dict(relpath_start))
-    ConfigFile(args.config_file).write_yaml(complist)
-    print("Components written to '{}'".format(args.config_file))
+    config_file_root_dir=os.path.join(relpath_start,args.config_file)
+    ConfigFile(config_file_root_dir).write_yaml(complist)
+    print(f"Components written to '{config_file_root_dir}'")
 
 def _update_comp(comp):
     git = GitRepository(comp.remote, comp.local)
     orig_ver = comp.version
     curr_ver = MepoVersion(*git.get_version())
     if _version_has_changed(curr_ver, orig_ver):
-        _verify_local_and_remote_commit_ids_match(git, curr_ver.name, comp.name)
+        _verify_local_and_remote_commit_ids_match(git, curr_ver.name, comp.name, curr_ver.type)
         comp.version = curr_ver
 
 def _version_has_changed(curr_ver, orig_ver):
     result = False
     if curr_ver != orig_ver:
-        assert curr_ver.type == 'b', '{}'.format(curr_ver)
-        assert curr_ver.detached is False, '{}'.format(curr_ver)
-        result = True
+        if curr_ver.type == 'b':
+            assert curr_ver.detached is False, '{}'.format(curr_ver)
+            result = True
+        elif curr_ver.type == 't':
+            result = True
+        elif curr_ver.type == 'h':
+            result = True
+        else:
+            raise Exception("This should not happen")
     return result
 
-def _verify_local_and_remote_commit_ids_match(git, curr_ver_name, comp_name):
-    remote_id = git.get_remote_latest_commit_id(curr_ver_name)
+def _verify_local_and_remote_commit_ids_match(git, curr_ver_name, comp_name, curr_ver_type):
+    remote_id = git.get_remote_latest_commit_id(curr_ver_name, curr_ver_type)
     local_id = git.get_local_latest_commit_id()
     failmsg = "{} (remote commit) != {} (local commit) for {}:{}. Did you try 'mepo push'?"
     if remote_id != local_id:

--- a/mepo.d/state/component.py
+++ b/mepo.d/state/component.py
@@ -26,7 +26,7 @@ class MepoComponent(object):
             ver_type = 'b'
         elif comp_details.get('hash', None):
             # Hashes don't have to exist
-            ver_name = comp_details['hash'][:7]
+            ver_name = comp_details['hash']
             ver_type = 'h'
         else:
             ver_name = comp_details['tag'] # 'tag' key has to exist
@@ -49,7 +49,9 @@ class MepoComponent(object):
         details['remote'] = self.remote
         if self.version.type == 't':
             details['tag'] = self.version.name
-        else: # if not tag, version has to be a branch
+        elif self.version.type == 'h':
+            details['hash'] = self.version.name
+        else: # if not tag or hash, version has to be a branch
             if self.version.detached: # SPECIAL HANDLING of 'detached head' branches
                 details['branch'] = self.version.name.replace('origin/', '')
             else:


### PR DESCRIPTION
Some issues were noted in trying out `mepo save`. It was saving the new yaml in the wrong place, and hashes weren't handled well.