### PR TITLE
Fixes #106. Allow mepo fixtures to be moved

### DIFF
--- a/mepo.d/repository/git.py
+++ b/mepo.d/repository/git.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import subprocess
 
+from state.state import MepoState
 from utilities import shellcmd
 from utilities import colors
 from urllib.parse import urljoin
@@ -10,20 +11,28 @@ class GitRepository(object):
     """
     Class to consolidate git commands
     """
-    __slots__ = ['__local', '__remote', '__git']
+    __slots__ = ['__local', '__full_local_path', '__remote', '__git']
 
     def __init__(self, remote_url, local_path):
         self.__local = local_path
+
         if remote_url.startswith('..'):
             rel_remote = os.path.basename(remote_url)
             fixture_url = get_current_remote_url()
             self.__remote = urljoin(fixture_url,rel_remote)
         else:
             self.__remote = remote_url
-        self.__git = 'git -C {}'.format(local_path)
+
+        root_dir = MepoState.get_root_dir()
+        full_local_path=os.path.join(root_dir,local_path)
+        self.__full_local_path=full_local_path
+        self.__git = 'git -C {}'.format(self.__full_local_path)
 
     def get_local_path(self):
         return self.__local
+
+    def get_full_local_path(self):
+        return self.__full_local_path
 
     def get_remote_url(self):
         return self.__remote
@@ -105,15 +114,16 @@ class GitRepository(object):
         shellcmd.run(cmd.split())
 
     def create_tag(self, tag_name, annotate, message, tf_file=None):
+        repo_path = get_full_local_path(self)
         if annotate:
             if tf_file:
-                cmd = ['git', '-C', self.__local, 'tag', '-a', '-F', tf_file, tag_name]
+                cmd = ['git', '-C', self.__full_local_path, 'tag', '-a', '-F', tf_file, tag_name]
             elif message:
-                cmd = ['git', '-C', self.__local, 'tag', '-a', '-m', message, tag_name]
+                cmd = ['git', '-C', self.__full_local_path, 'tag', '-a', '-m', message, tag_name]
             else:
                 raise Exception("This should not happen")
         else:
-            cmd = ['git', '-C', self.__local, 'tag', tag_name]
+            cmd = ['git', '-C', self.__full_local_path, 'tag', tag_name]
         shellcmd.run(cmd)
 
     def delete_branch(self, branch_name, force):
@@ -236,10 +246,11 @@ class GitRepository(object):
         shellcmd.run(cmd.split())
 
     def commit_files(self, message, tf_file=None):
+        repo_path = get_full_local_path(self)
         if tf_file:
-            cmd = ['git', '-C', self.__local, 'commit', '-F', tf_file]
+            cmd = ['git', '-C', self.__full_local_path, 'commit', '-F', tf_file]
         elif message:
-            cmd = ['git', '-C', self.__local, 'commit', '-m', message]
+            cmd = ['git', '-C', self.__full_local_path, 'commit', '-m', message]
         else:
             raise Exception("This should not happen")
         shellcmd.run(cmd)

--- a/mepo.d/repository/git.py
+++ b/mepo.d/repository/git.py
@@ -114,7 +114,6 @@ class GitRepository(object):
         shellcmd.run(cmd.split())
 
     def create_tag(self, tag_name, annotate, message, tf_file=None):
-        repo_path = get_full_local_path(self)
         if annotate:
             if tf_file:
                 cmd = ['git', '-C', self.__full_local_path, 'tag', '-a', '-F', tf_file, tag_name]
@@ -246,7 +245,6 @@ class GitRepository(object):
         shellcmd.run(cmd.split())
 
     def commit_files(self, message, tf_file=None):
-        repo_path = get_full_local_path(self)
         if tf_file:
             cmd = ['git', '-C', self.__full_local_path, 'commit', '-F', tf_file]
         elif message:

--- a/mepo.d/state/component.py
+++ b/mepo.d/state/component.py
@@ -45,7 +45,7 @@ class MepoComponent(object):
 
     def to_dict(self, start):
         details = dict()
-        details['local'] = './' + os.path.relpath(self.local, start)
+        details['local'] = self.local
         details['remote'] = self.remote
         if self.version.type == 't':
             details['tag'] = self.version.name

--- a/mepo.d/state/component.py
+++ b/mepo.d/state/component.py
@@ -35,7 +35,7 @@ class MepoComponent(object):
         
     def to_component(self, comp_name, comp_details):
         self.name = comp_name
-        self.local = os.path.abspath(comp_details['local'])
+        self.local = comp_details['local']
         self.remote = comp_details['remote']
         self.develop = comp_details.get('develop', None) # develop is optional
         self.sparse = comp_details.get('sparse', None) # sparse is optional

--- a/mepo.d/state/state.py
+++ b/mepo.d/state/state.py
@@ -87,8 +87,8 @@ class MepoState(object):
             pickle.dump(state_details, fout, -1)
         state_fileptr = cls.__state_fileptr_name
         state_fileptr_fullpath = os.path.join(state_dir, state_fileptr)
-        if os.path.isfile(state_fileptr):
-            os.remove(state_fileptr)
+        if os.path.isfile(state_fileptr_fullpath):
+            os.remove(state_fileptr_fullpath)
         #os.symlink(new_state_file, state_fileptr_fullpath)
         curr_dir=os.getcwd()
         os.chdir(state_dir)

--- a/mepo.d/state/state.py
+++ b/mepo.d/state/state.py
@@ -85,7 +85,12 @@ class MepoState(object):
         new_state_file = os.path.join(state_dir, state_file_name)
         with open(new_state_file, 'wb') as fout:
             pickle.dump(state_details, fout, -1)
-        state_fileptr = os.path.join(state_dir, cls.__state_fileptr_name)
+        state_fileptr = cls.__state_fileptr_name
+        state_fileptr_fullpath = os.path.join(state_dir, state_fileptr)
         if os.path.isfile(state_fileptr):
             os.remove(state_fileptr)
-        os.symlink(new_state_file, state_fileptr)
+        #os.symlink(new_state_file, state_fileptr_fullpath)
+        curr_dir=os.getcwd()
+        os.chdir(state_dir)
+        os.symlink(state_file_name, state_fileptr)
+        os.chdir(curr_dir)


### PR DESCRIPTION
This PR fixes #106. The issue was that full paths were hardcoded into the mepo state at initialization time. Instead, we now store local/relative paths and then do operations on full paths relative to where the `.mepo/` directory is.