### PR TITLE
Remove origin/ from status for clarity

### DIFF
--- a/mepo.d/command/compare/compare.py
+++ b/mepo.d/command/compare/compare.py
@@ -4,6 +4,8 @@ from utilities.version import version_to_string
 from repository.git import GitRepository
 from shutil import get_terminal_size
 
+VER_LEN = 30
+
 def run(args):
     allcomps = MepoState.read_state()
     max_namelen = len(max([x.name for x in allcomps], key=len))
@@ -16,11 +18,6 @@ def run(args):
         print_cmp(comp.name, orig_ver, curr_ver, max_namelen, max_origlen)
 
 def print_header(max_namelen, max_origlen):
-    # This is to remove to remove padding in the header for colorizing the
-    # (DH) bit of the branch/tag orig name
-    DH_COLOR_LEN = len(colors.YELLOW + colors.RESET)
-    max_origlen = max_origlen - DH_COLOR_LEN
-
     FMT_VAL = (max_namelen, max_namelen, max_origlen)
     FMTHEAD = '{:<%s.%ss} | {:<%ss} | {:<s}' % FMT_VAL
     print(FMTHEAD.format("Repo","Original","Current"))

--- a/mepo.d/command/compare/compare.py
+++ b/mepo.d/command/compare/compare.py
@@ -4,8 +4,6 @@ from utilities.version import version_to_string
 from repository.git import GitRepository
 from shutil import get_terminal_size
 
-VER_LEN = 30
-
 def run(args):
     allcomps = MepoState.read_state()
     max_namelen = len(max([x.name for x in allcomps], key=len))
@@ -18,6 +16,11 @@ def run(args):
         print_cmp(comp.name, orig_ver, curr_ver, max_namelen, max_origlen)
 
 def print_header(max_namelen, max_origlen):
+    # This is to remove to remove padding in the header for colorizing the
+    # (DH) bit of the branch/tag orig name
+    DH_COLOR_LEN = len(colors.YELLOW + colors.RESET)
+    max_origlen = max_origlen - DH_COLOR_LEN
+
     FMT_VAL = (max_namelen, max_namelen, max_origlen)
     FMTHEAD = '{:<%s.%ss} | {:<%ss} | {:<s}' % FMT_VAL
     print(FMTHEAD.format("Repo","Original","Current"))

--- a/mepo.d/command/diff/diff.py
+++ b/mepo.d/command/diff/diff.py
@@ -5,7 +5,6 @@ import os
 
 from state.state import MepoState
 from repository.git import GitRepository
-from utilities.version import version_to_string
 from utilities import verify
 
 from shutil import get_terminal_size

--- a/mepo.d/command/status/status.py
+++ b/mepo.d/command/status/status.py
@@ -16,16 +16,22 @@ def run(args):
 
 def check_component_status(comp):
     git = GitRepository(comp.remote, comp.local)
+
+    # version_to_string can strip off 'origin/' for display purposes
+    # so we save the "internal" name for comparison
+    internal_state_branch_name = git.get_version()[0]
+
+    # This can return non "origin/" names for detached head branches
     curr_ver = version_to_string(git.get_version())
-    return (curr_ver, git.check_status())
+    return (curr_ver, internal_state_branch_name, git.check_status())
 
 def print_status(allcomps, result):
     orig_width = len(max([comp.name for comp in allcomps], key=len))
     for index, comp in enumerate(allcomps):
         time.sleep(0.025)
-        current_version, output = result[index]
+        current_version, internal_state_branch_name, output = result[index]
         # Check to see if the current tag/branch is the same as the original
-        if comp.version.name not in current_version:
+        if comp.version.name not in internal_state_branch_name:
             component_name = colors.RED + comp.name + colors.RESET
             width = orig_width + len(colors.RED) + len(colors.RESET)
         else:

--- a/mepo.d/utilities/version.py
+++ b/mepo.d/utilities/version.py
@@ -1,4 +1,5 @@
 from collections import namedtuple
+from utilities import colors
 
 MepoVersion = namedtuple('MepoVersion', ['name', 'type', 'detached'])
 
@@ -11,7 +12,7 @@ def version_to_string(version):
         # We remove the "origin/" from the internal detached branch name 
         # for clarity in mepo status output
         version_name = version_name.replace('origin/','')
-        s = f'({version_type}) {version_name} (DH)'
+        s = f'({version_type}) {version_name} {colors.YELLOW}(DH){colors.RESET}'
     else:
         s = f'({version_type}) {version_name}'
     return s

--- a/mepo.d/utilities/version.py
+++ b/mepo.d/utilities/version.py
@@ -3,7 +3,15 @@ from collections import namedtuple
 MepoVersion = namedtuple('MepoVersion', ['name', 'type', 'detached'])
 
 def version_to_string(version):
-    s = '({}) {}'.format(version[1], version[0])
-    if version[2]: # detached head
-        s += ' (DH)'
+    version_name     = version[0]
+    version_type     = version[1]
+    version_detached = version[2]
+
+    if version_detached: # detached head
+        # We remove the "origin/" from the internal detached branch name 
+        # for clarity in mepo status output
+        version_name = version_name.replace('origin/','')
+        s = f'({version_type}) {version_name} (DH)'
+    else:
+        s = f'({version_type}) {version_name}'
     return s

--- a/mepo.d/utilities/version.py
+++ b/mepo.d/utilities/version.py
@@ -1,5 +1,4 @@
 from collections import namedtuple
-from utilities import colors
 
 MepoVersion = namedtuple('MepoVersion', ['name', 'type', 'detached'])
 
@@ -12,7 +11,7 @@ def version_to_string(version):
         # We remove the "origin/" from the internal detached branch name 
         # for clarity in mepo status output
         version_name = version_name.replace('origin/','')
-        s = f'({version_type}) {version_name} {colors.YELLOW}(DH){colors.RESET}'
+        s = f'({version_type}) {version_name} (DH)'
     else:
         s = f'({version_type}) {version_name}'
     return s


### PR DESCRIPTION
This is a bit of "nicety" for `mepo status`. Before if you checked out a model with branches in `components.yaml` you got:
```console
❯ mepo status
Checking status...
env                    | (b) origin/feature/bmauer/updates-from-geosadas5_27_0 (DH)
cmake                  | (t) v1.0.11 (DH)
ecbuild                | (t) geos/v1.0.0 (DH)
NCEP_Shared            | (b) origin/feature/mathomp4/update-to-geosadas527 (DH)
GMAO_Shared            | (b) origin/feature/bmauer/updates-from-geosadas5_27_0 (DH)
MAPL                   | (b) origin/feature/bmauer/updates-from-geosadas5_27_0 (DH)
FMS                    | (t) geos/orphan/v1.0.3 (DH)
GEOSana_GridComp       | (b) origin/feature/mathomp4/update-to-geosadas527-withoutMAPL2changes (DH)
GEOSgcm_GridComp       | (b) origin/feature/bmauer/updates-from-geosadas5_27_0 (DH)
g5pert                 | (b) origin/feature/mathomp4/update-to-geosadas527 (DH)
GEOSagcmPert_GridComp  | (b) origin/feature/bmauer/updates-from-geosadas5_27_0 (DH)
FVdycoreCubed_GridComp | (t) v1.0.9 (DH)
fvdycore               | (t) geos/v1.0.2 (DH)
GEOSchem_GridComp      | (b) origin/feature/bmauer/updates-from-geosadas5_27_0 (DH)
mom                    | (t) geos/v1.0.1 (DH)
GEOSgcm_App            | (b) origin/feature/bmauer/updates-from-geosadas5_27_0 (DH)
UMD_Etc                | (t) v1.0.2 (DH)
CPLFCST_Etc            | (t) v1.0.1 (DH)
```
This isn't bad, but that `origin/` bit on the detached head branches is ugly. Plus, let's say you wanted to move to that branch, and you do copy/paste. Well:
```console
❯ mepo checkout origin/feature/bmauer/updates-from-geosadas5_27_0 GEOSagcmPert_GridComp
❯ mepo status
Checking status...
env                    | (b) origin/feature/bmauer/updates-from-geosadas5_27_0 (DH)
cmake                  | (t) v1.0.11 (DH)
ecbuild                | (t) geos/v1.0.0 (DH)
NCEP_Shared            | (b) origin/feature/mathomp4/update-to-geosadas527 (DH)
GMAO_Shared            | (b) origin/feature/bmauer/updates-from-geosadas5_27_0 (DH)
MAPL                   | (b) origin/feature/bmauer/updates-from-geosadas5_27_0 (DH)
FMS                    | (t) geos/orphan/v1.0.3 (DH)
GEOSana_GridComp       | (b) origin/feature/mathomp4/update-to-geosadas527-withoutMAPL2changes (DH)
GEOSgcm_GridComp       | (b) origin/feature/bmauer/updates-from-geosadas5_27_0 (DH)
g5pert                 | (b) origin/feature/mathomp4/update-to-geosadas527 (DH)
GEOSagcmPert_GridComp  | (b) origin/feature/bmauer/updates-from-geosadas5_27_0 (DH)
FVdycoreCubed_GridComp | (t) v1.0.9 (DH)
fvdycore               | (t) geos/v1.0.2 (DH)
GEOSchem_GridComp      | (b) origin/feature/bmauer/updates-from-geosadas5_27_0 (DH)
mom                    | (t) geos/v1.0.1 (DH)
GEOSgcm_App            | (b) origin/feature/bmauer/updates-from-geosadas5_27_0 (DH)
UMD_Etc                | (t) v1.0.2 (DH)
CPLFCST_Etc            | (t) v1.0.1 (DH)
```
Instead the user needs to know to remove the `origin/` from the branch name. Instead, with this PR, the `mepo status` will now look like:
```console
❯ mepo status
Checking status...
env                    | (b) feature/bmauer/updates-from-geosadas5_27_0 (DH)
cmake                  | (t) v1.0.11 (DH)
ecbuild                | (t) geos/v1.0.0 (DH)
NCEP_Shared            | (b) feature/mathomp4/update-to-geosadas527 (DH)
GMAO_Shared            | (b) feature/bmauer/updates-from-geosadas5_27_0 (DH)
MAPL                   | (b) feature/bmauer/updates-from-geosadas5_27_0 (DH)
FMS                    | (t) geos/orphan/v1.0.3 (DH)
GEOSana_GridComp       | (b) feature/mathomp4/update-to-geosadas527-withoutMAPL2changes (DH)
GEOSgcm_GridComp       | (b) feature/bmauer/updates-from-geosadas5_27_0 (DH)
g5pert                 | (b) feature/mathomp4/update-to-geosadas527 (DH)
GEOSagcmPert_GridComp  | (b) feature/bmauer/updates-from-geosadas5_27_0 (DH)
FVdycoreCubed_GridComp | (t) v1.0.9 (DH)
fvdycore               | (t) geos/v1.0.2 (DH)
GEOSchem_GridComp      | (b) feature/bmauer/updates-from-geosadas5_27_0 (DH)
mom                    | (t) geos/v1.0.1 (DH)
GEOSgcm_App            | (b) feature/bmauer/updates-from-geosadas5_27_0 (DH)
UMD_Etc                | (t) v1.0.2 (DH)
CPLFCST_Etc            | (t) v1.0.1 (DH)
```
So the `origin/` is removed from the *status* output (not internally), but the `(DH)` is still there to let you know "detached HEAD". But, now a user can copy-paste:
```console
❯ mepo checkout feature/bmauer/updates-from-geosadas5_27_0 GEOSagcmPert_GridComp
❯ mepo status
Checking status...
env                    | (b) feature/bmauer/updates-from-geosadas5_27_0 (DH)
cmake                  | (t) v1.0.11 (DH)
ecbuild                | (t) geos/v1.0.0 (DH)
NCEP_Shared            | (b) feature/mathomp4/update-to-geosadas527 (DH)
GMAO_Shared            | (b) feature/bmauer/updates-from-geosadas5_27_0 (DH)
MAPL                   | (b) feature/bmauer/updates-from-geosadas5_27_0 (DH)
FMS                    | (t) geos/orphan/v1.0.3 (DH)
GEOSana_GridComp       | (b) feature/mathomp4/update-to-geosadas527-withoutMAPL2changes (DH)
GEOSgcm_GridComp       | (b) feature/bmauer/updates-from-geosadas5_27_0 (DH)
g5pert                 | (b) feature/mathomp4/update-to-geosadas527 (DH)
GEOSagcmPert_GridComp  | (b) feature/bmauer/updates-from-geosadas5_27_0
FVdycoreCubed_GridComp | (t) v1.0.9 (DH)
fvdycore               | (t) geos/v1.0.2 (DH)
GEOSchem_GridComp      | (b) feature/bmauer/updates-from-geosadas5_27_0 (DH)
mom                    | (t) geos/v1.0.1 (DH)
GEOSgcm_App            | (b) feature/bmauer/updates-from-geosadas5_27_0 (DH)
UMD_Etc                | (t) v1.0.2 (DH)
CPLFCST_Etc            | (t) v1.0.1 (DH)
```
Now, in this example, GEOSagcmPert_GridComp is now on the (HEAD of the) `feature/bmauer/updates-from-geosadas5_27_0` branch. 