### PR TITLE
Add mepo-cd.csh

### DIFF
--- a/etc/mepo-cd.csh
+++ b/etc/mepo-cd.csh
@@ -1,0 +1,1 @@
+alias mepo-cd 'cd `mepo whereis \!:1`'


### PR DESCRIPTION
Adds `mepo-cd.csh` which defines a `mepo-cd` alias.