### PR TITLE
Fixes for CI systems that use shallow clones

### DIFF
--- a/mepo.d/repository/git.py
+++ b/mepo.d/repository/git.py
@@ -317,6 +317,12 @@ class GitRepository(object):
             detached = True
             name = hash_out.rstrip()
             tYpe = 'h'
+        elif output.startswith('grafted'):
+            cmd = self.__git + ' describe --always'
+            hash_out = shellcmd.run(cmd.split(), output=True)
+            detached = True
+            name = hash_out.rstrip()
+            tYpe = 'h'
         return (name, tYpe, detached)
 
 def get_current_remote_url():


### PR DESCRIPTION
Some CI systems clone things in odd ways. This fixes `mepo init` and `mepo status` to the point where they will work (on GitHub Actions at least). No regular user will ever do like they do as `git clone` is the "sane" way.