### PR TITLE
Fix for clone-config bug

### DIFF
--- a/mepo.d/cmdline/parser.py
+++ b/mepo.d/cmdline/parser.py
@@ -79,7 +79,7 @@ class MepoArgParser(object):
             metavar = 'config-file',
             nargs = '?',
             default = None,
-            help = 'Configuration file (ignored if init already called, default: %(default)s)')
+            help = 'Configuration file (ignored if init already called)')
 
     def __list(self):
         listcomps = self.subparsers.add_parser(

--- a/mepo.d/cmdline/parser.py
+++ b/mepo.d/cmdline/parser.py
@@ -78,7 +78,7 @@ class MepoArgParser(object):
             '--config',
             metavar = 'config-file',
             nargs = '?',
-            default = 'components.yaml',
+            default = None,
             help = 'Configuration file (ignored if init already called, default: %(default)s)')
 
     def __list(self):

--- a/mepo.d/command/clone/clone.py
+++ b/mepo.d/command/clone/clone.py
@@ -16,8 +16,14 @@ def run(args):
 
     # If you pass in a config, with clone, it could be outside the repo.
     # So use the full path
+    passed_in_config = False
     if args.config:
+        passed_in_config = True
         args.config = os.path.abspath(args.config)
+    else:
+        # If we don't pass in a config, we need to "reset" the arg to the
+        # default name because we pass args to mepo_init
+        args.config = 'components.yaml'
 
     if args.repo_url:
         p = urlparse(args.repo_url)
@@ -35,8 +41,8 @@ def run(args):
             local_clone(args.repo_url,args.branch)
             os.chdir(git_url_directory)
 
-    # Copy the new file into the repo
-    if args.config:
+    # Copy the new file into the repo only if we pass it in
+    if passed_in_config:
         shutil.copy(args.config,os.getcwd())
 
     # This tries to read the state and if not, calls init,

--- a/mepo.d/command/clone/clone.py
+++ b/mepo.d/command/clone/clone.py
@@ -43,7 +43,10 @@ def run(args):
 
     # Copy the new file into the repo only if we pass it in
     if passed_in_config:
-        shutil.copy(args.config,os.getcwd())
+        try:
+            shutil.copy(args.config,os.getcwd())
+        except shutil.SameFileError as e:
+            pass
 
     # This tries to read the state and if not, calls init,
     # loops back, and reads the state


### PR DESCRIPTION
The last fix for cloning with config broke all-in-one cloning *without* config. Sigh. Bad Matt. This fixes that.