### PR TITLE
Fix bug with mepo status on odd branches

### DIFF
--- a/mepo.d/command/save/save.py
+++ b/mepo.d/command/save/save.py
@@ -24,15 +24,15 @@ def _update_comp(comp):
     git = GitRepository(comp.remote, comp.local)
     orig_ver = comp.version
     curr_ver = MepoVersion(*git.get_version())
-    if _version_has_changed(curr_ver, orig_ver):
+    if _version_has_changed(curr_ver, orig_ver, comp.name):
         _verify_local_and_remote_commit_ids_match(git, curr_ver.name, comp.name, curr_ver.type)
         comp.version = curr_ver
 
-def _version_has_changed(curr_ver, orig_ver):
+def _version_has_changed(curr_ver, orig_ver, name):
     result = False
     if curr_ver != orig_ver:
         if curr_ver.type == 'b':
-            assert curr_ver.detached is False, '{}'.format(curr_ver)
+            assert curr_ver.detached is False, f'You cannot save a detached branch, have you committed your code in {name}?\n {curr_ver}'
             result = True
         elif curr_ver.type == 't':
             result = True

--- a/mepo.d/repository/git.py
+++ b/mepo.d/repository/git.py
@@ -313,7 +313,9 @@ class GitRepository(object):
                 name = tmp[5:]
                 tYpe = 't'
             else:
-                name = tmp
+                cmd_for_branch = self.__git + ' reflog HEAD -n 1'
+                reflog_output = shellcmd.run(cmd_for_branch.split(), output=True)
+                name = reflog_output.split()[-1].strip()
                 tYpe = 'b'
         elif output.startswith('HEAD'): # Assume hash
             cmd = self.__git + ' rev-parse HEAD'


### PR DESCRIPTION
This is an interesting bug. So, the way mepo was figuring out what branch you were on with detached head was:
```
git show -s --pretty=%D HEAD
```
and then taking the second field. In most cases, this is fine, but sometimes you have two branches that are identical:
```console
❯ git show -s --pretty=%D HEAD
HEAD, origin/feature/wputman/dyamond_v2, origin/develop, origin/HEAD, develop
```
So, even though you checked out `develop`, `mepo status` was returning that after running `mepo clone` you were on `feature/wputman/dyamond_v2`. While this isn't incorrect, it's not quite right and mepo shows a difference.

After looking at the git source code, I think it uses the internals used for the reflog to get this. If I look at the `git-reflog` output:
```console
❯ git reflog
eb7e199 (HEAD, origin/feature/wputman/dyamond_v2, origin/develop, origin/HEAD, develop) HEAD@{0}: checkout: moving from develop to origin/develop
eb7e199 (HEAD, origin/feature/wputman/dyamond_v2, origin/develop, origin/HEAD, develop) HEAD@{1}: clone: from github.com:GEOS-ESM/GEOSgcm_GridComp.git
```
Now we see internally it knows we checked out `develop` and then detached to `origin/develop`. We can capture this knowledge with `git reflog HEAD -n 1` and then take the last part of the string.

I also clean up an odd save issue.