### PR TITLE
Add EditorConfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+; Global Editor Config for mepo
+;
+; This is an ini style configuration. See http://editorconfig.org/ for more information on this file.
+;
+; Top level editor config.
+root = true
+; Always use Unix style new lines with new line ending on every file and trim whitespace
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+; Python: PEP8 defines 4 spaces for indentation
+[*.py]
+indent_style = space
+indent_size = 4
+; Salt state files, YAML format, 2 spaces
+[*.sls, *.yaml, *.yml]
+indent_style = space
+indent_size = 2
+


### PR DESCRIPTION
After learning about [EditorConfig](https://editorconfig.org/), I figured `mepo` might be a good place to try it out. I think this does the style we like. 4-space-indent Python and 2-space indent yaml. And NO TABS! 😄 