### PR TITLE
Add useful checkout messages

### DIFF
--- a/mepo.d/cmdline/parser.py
+++ b/mepo.d/cmdline/parser.py
@@ -123,13 +123,14 @@ class MepoArgParser(object):
         checkout.add_argument('branch_name', metavar = 'branch-name')
         checkout.add_argument('comp_name', metavar = 'comp-name', nargs = '+')
         checkout.add_argument('-b', action = 'store_true', help = 'create the branch')
+        checkout.add_argument('--quiet', action = 'store_true', help = 'Suppress prints')
 
     def __checkout_if_exists(self):
         checkout_if_exists = self.subparsers.add_parser(
             'checkout-if-exists',
             description = 'Switch to branch <branch-name> in any component where it is present. ')
         checkout_if_exists.add_argument('branch_name', metavar = 'branch-name')
-        checkout_if_exists.add_argument('--quiet', action = 'store_true', help = 'Suppress found messages')
+        checkout_if_exists.add_argument('--quiet', action = 'store_true', help = 'Suppress prints')
         checkout_if_exists.add_argument('--dry-run','-n', action = 'store_true', help = 'Dry-run only (lists repos where branch exists)')
 
     def __fetch(self):
@@ -176,6 +177,7 @@ class MepoArgParser(object):
             'develop',
             description = "Checkout current version of 'develop' branches of specified components")
         develop.add_argument('comp_name', metavar = 'comp-name', nargs = '+', default = None)
+        develop.add_argument('--quiet', action = 'store_true', help = 'Suppress prints')
 
     def __pull(self):
         pull = self.subparsers.add_parser(

--- a/mepo.d/command/checkout/checkout.py
+++ b/mepo.d/command/checkout/checkout.py
@@ -1,6 +1,7 @@
 from state.state import MepoState
 from utilities import verify
 from repository.git import GitRepository
+from utilities import colors
 
 def run(args):
     allcomps = MepoState.read_state()
@@ -11,5 +12,14 @@ def run(args):
         branch = args.branch_name
         if args.b:
             git.create_branch(branch)
-            print('+ {}: {}'.format(comp.name, branch))
+            if not args.quiet:
+                #print('+ {}: {}'.format(comp.name, branch))
+                print("Creating and checking out branch %s in %s" %
+                        (colors.YELLOW + branch + colors.RESET,
+                        colors.RESET + comp.name + colors.RESET))
+        else:
+            if not args.quiet:
+                print("Checking out %s in %s" %
+                        (colors.YELLOW + branch + colors.RESET,
+                        colors.RESET + comp.name + colors.RESET))
         git.checkout(branch)

--- a/mepo.d/command/develop/develop.py
+++ b/mepo.d/command/develop/develop.py
@@ -1,6 +1,7 @@
 from state.state import MepoState
 from utilities import verify
 from repository.git import GitRepository
+from utilities import colors
 
 def run(args):
     allcomps = MepoState.read_state()
@@ -10,5 +11,9 @@ def run(args):
         git = GitRepository(comp.remote, comp.local)
         if comp.develop is None:
             raise Exception("'develop' branch not specified for {}".format(comp.name))
+        if not args.quiet:
+            print("Checking out development branch %s in %s" %
+                    (colors.YELLOW + comp.develop + colors.RESET,
+                    colors.RESET + comp.name + colors.RESET))
         git.checkout(comp.develop)
         git.pull()


### PR DESCRIPTION
This PR adds some useful prints to `mepo checkout` and `mepo develop` such that if you do:
```console
❯ mepo checkout v3.1.3 ESMA_env
Checking out v3.1.3 in ESMA_env
❯ mepo checkout -b feature/amazing ESMA_cmake
Creating and checking out branch feature/amazing in ESMA_cmake
❯ mepo develop MAPL
Checking out development branch develop in MAPL
```
Probably more places `mepo` can be verbose, but this was an easy one.

Note: I've added `--quiet` option to them to suppress prints if wanted.