### PR TITLE
Add support for a style option for repo indicator

### DIFF
--- a/mepo.d/cmdline/parser.py
+++ b/mepo.d/cmdline/parser.py
@@ -52,6 +52,13 @@ class MepoArgParser(object):
             nargs = '?',
             default = 'components.yaml',
             help = 'default: %(default)s')
+        init.add_argument(
+            '--style',
+            metavar = 'style-type',
+            nargs = '?',
+            default = 'prefix',
+            choices = ['naked', 'prefix','postfix'],
+            help = 'Style of directory file, default: %(default)s, allowed options: %(choices)s')
 
     def __clone(self):
         clone = self.subparsers.add_parser(
@@ -80,6 +87,13 @@ class MepoArgParser(object):
             nargs = '?',
             default = None,
             help = 'Configuration file (ignored if init already called)')
+        clone.add_argument(
+            '--style',
+            metavar = 'style-type',
+            nargs = '?',
+            default = 'prefix',
+            choices = ['naked', 'prefix','postfix'],
+            help = 'Style of directory file, default: %(default)s, allowed options: %(choices)s (ignored if init already called)')
 
     def __list(self):
         listcomps = self.subparsers.add_parser(

--- a/mepo.d/command/init/init.py
+++ b/mepo.d/command/init/init.py
@@ -1,5 +1,5 @@
 from state.state import MepoState
 
 def run(args):
-    allcomps = MepoState.initialize(args.config)
-    print('Initializing mepo using {}'.format(args.config))
+    allcomps = MepoState.initialize(args.config,args.style)
+    print(f'Initializing mepo using {args.config} with {args.style} style.')

--- a/mepo.d/command/restore-state/restore-state.py
+++ b/mepo.d/command/restore-state/restore-state.py
@@ -1,6 +1,7 @@
 import sys
 import time
 import multiprocessing as mp
+import atexit
 
 from state.state import MepoState
 from repository.git import GitRepository
@@ -11,6 +12,7 @@ def run(args):
     print('Checking status...'); sys.stdout.flush()
     allcomps = MepoState.read_state()
     pool = mp.Pool()
+    atexit.register(pool.close)
     result = pool.map(check_component_status, allcomps)
     restore_state(allcomps, result)
 

--- a/mepo.d/command/status/status.py
+++ b/mepo.d/command/status/status.py
@@ -1,6 +1,7 @@
 import sys
 import time
 import multiprocessing as mp
+import atexit
 
 from state.state import MepoState
 from repository.git import GitRepository
@@ -11,6 +12,7 @@ def run(args):
     print('Checking status...'); sys.stdout.flush()
     allcomps = MepoState.read_state()
     pool = mp.Pool()
+    atexit.register(pool.close)
     result = pool.map(check_component_status, allcomps)
     print_status(allcomps, result)
 

--- a/mepo.d/state/state.py
+++ b/mepo.d/state/state.py
@@ -53,7 +53,7 @@ class MepoState(object):
             return False
 
     @classmethod
-    def initialize(cls, project_config_file):
+    def initialize(cls, project_config_file, directory_style):
         if cls.exists():
             raise StateAlreadyInitializedError('mepo state already exists')
         input_components = ConfigFile(project_config_file).read_file()
@@ -67,7 +67,7 @@ class MepoState(object):
             if num_fixture > 1:
                 raise Exception("Only one fixture allowed")
 
-            complist.append(MepoComponent().to_component(name, comp))
+            complist.append(MepoComponent().to_component(name, comp, directory_style))
         cls.write_state(complist)
 
     @classmethod

--- a/mepo.d/utest/input/components.yaml
+++ b/mepo.d/utest/input/components.yaml
@@ -1,48 +1,52 @@
+GEOSfvdycore:
+  fixture: true
+  develop: main
+
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v2.1.3
-  develop: master
+  tag: v3.2.0
+  develop: main
 
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.0.2
+  tag: v3.3.9
   develop: develop
 
 ecbuild:
   local: ./@cmake/@ecbuild
   remote: ../ecbuild.git
-  tag: geos/v1.0.1
+  tag: geos/v1.0.6
 
 GMAO_Shared:
   local: ./src/Shared/@GMAO_Shared
   remote: ../GMAO_Shared.git
-  tag: v1.1.3
+  tag: v1.3.10
   sparse: ./config/GMAO_Shared.sparse
-  develop: master
+  develop: main
 
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.1.3
+  tag: v2.6.4
   develop: develop
 
 FMS:
   local: ./src/Shared/@FMS
   remote: ../FMS.git
-  tag: geos/2019.01.01
-  develop: geos/master
+  tag: geos/2019.01.02+noaff.6
+  develop: geos/release/2019.01
 
 FVdycoreCubed_GridComp:
   local: ./src/Components/@FVdycoreCubed_GridComp
   remote: ../FVdycoreCubed_GridComp.git
-  tag: v1.1.0
+  tag: v1.2.12
   develop: develop
 
 fvdycore:
   local: ./src/Components/@FVdycoreCubed_GridComp/@fvdycore
   remote: ../GFDL_atmos_cubed_sphere.git
-  tag: geos/v1.1.0
+  tag: geos/v1.1.6
   develop: geos/develop
 

--- a/mepo.d/utest/output/compare_no_change.txt
+++ b/mepo.d/utest/output/compare_no_change.txt
@@ -1,0 +1,11 @@
+Repo                   | Original                         | Current
+---------------------- | -------------------------------- | -------
+GEOSfvdycore           | (b) main                         | (b) main
+env                    | (t) v3.2.0 (DH)                  | (t) v3.2.0 (DH)
+cmake                  | (t) v3.3.9 (DH)                  | (t) v3.3.9 (DH)
+ecbuild                | (t) geos/v1.0.6 (DH)             | (t) geos/v1.0.6 (DH)
+GMAO_Shared            | (t) v1.3.10 (DH)                 | (t) v1.3.10 (DH)
+MAPL                   | (t) v2.6.4 (DH)                  | (t) v2.6.4 (DH)
+FMS                    | (t) geos/2019.01.02+noaff.6 (DH) | (t) geos/2019.01.02+noaff.6 (DH)
+FVdycoreCubed_GridComp | (t) v1.2.12 (DH)                 | (t) v1.2.12 (DH)
+fvdycore               | (t) geos/v1.1.6 (DH)             | (t) geos/v1.1.6 (DH)

--- a/mepo.d/utest/output/list_output.txt
+++ b/mepo.d/utest/output/list_output.txt
@@ -1,1 +1,1 @@
-env cmake ecbuild GMAO_Shared MAPL FMS FVdycoreCubed_GridComp fvdycore 
+GEOSfvdycore env cmake ecbuild GMAO_Shared MAPL FMS FVdycoreCubed_GridComp fvdycore 

--- a/mepo.d/utest/output/status_output.txt
+++ b/mepo.d/utest/output/status_output.txt
@@ -1,9 +1,10 @@
 Checking status...
-env                    | (t) v2.1.3 (DH)
-cmake                  | (t) v3.0.2 (DH)
-ecbuild                | (t) geos/v1.0.1 (DH)
-GMAO_Shared            | (t) v1.1.3 (DH)
-MAPL                   | (t) v2.1.3 (DH)
-FMS                    | (t) geos/2019.01.01 (DH)
-FVdycoreCubed_GridComp | (t) v1.1.0 (DH)
-fvdycore               | (t) geos/v1.1.0 (DH)
+GEOSfvdycore           | (b) main
+env                    | (t) v3.2.0 (DH)
+cmake                  | (t) v3.3.9 (DH)
+ecbuild                | (t) geos/v1.0.6 (DH)
+GMAO_Shared            | (t) v1.3.10 (DH)
+MAPL                   | (t) v2.6.4 (DH)
+FMS                    | (t) geos/2019.01.02+noaff.6 (DH)
+FVdycoreCubed_GridComp | (t) v1.2.12 (DH)
+fvdycore               | (t) geos/v1.1.6 (DH)

--- a/mepo.d/utest/test_mepo_commands.py
+++ b/mepo.d/utest/test_mepo_commands.py
@@ -9,11 +9,10 @@ from io import StringIO
 
 from input import args
 
-from command.init    import init    as mepo_init
-from command.clone   import clone   as mepo_clone
-from command.list    import list    as mepo_list
-from command.status  import status  as mepo_status
-from command.compare import compare as mepo_compare
+from command.init   import init   as mepo_init
+from command.clone  import clone  as mepo_clone
+from command.list   import list   as mepo_list
+from command.status import status as mepo_status
 
 class TestMepoCommands(unittest.TestCase):
 
@@ -66,14 +65,6 @@ class TestMepoCommands(unittest.TestCase):
         mepo_status.run(args)
         sys.stdout = sys.__stdout__
         with open(os.path.join(self.__class__.output_dir, 'status_output.txt'), 'r') as fin:
-            saved_output = fin.read()
-        self.assertEqual(output.getvalue(), saved_output)
-
-    def test_compare_no_change(self):
-        sys.stdout = output = StringIO()
-        mepo_compare.run(args)
-        sys.stdout = sys.__stdout__
-        with open(os.path.join(self.__class__.output_dir, 'compare_no_change.txt'), 'r') as fin:
             saved_output = fin.read()
         self.assertEqual(output.getvalue(), saved_output)
 

--- a/mepo.d/utest/test_mepo_commands.py
+++ b/mepo.d/utest/test_mepo_commands.py
@@ -9,10 +9,10 @@ from io import StringIO
 
 from input import args
 
-from command.init import init as mepo_init
-from command.clone import clone as mepo_clone
-from command.list import list as mepo_list
-from command.status import status as mepo_status
+from command.init     import init   as mepo_init
+from command.clone    import clone  as mepo_clone
+from command.list     import list   as mepo_list
+from command.status   import status as mepo_status
 
 class TestMepoCommands(unittest.TestCase):
 
@@ -40,6 +40,7 @@ class TestMepoCommands(unittest.TestCase):
         cls.__checkout_fixture()
         cls.__copy_config_file()
         args.config = 'components.yaml'
+        args.style = 'prefix'
         os.chdir(cls.fixture_dir)
         mepo_init.run(args)
         args.config = None

--- a/mepo.d/utest/test_mepo_commands.py
+++ b/mepo.d/utest/test_mepo_commands.py
@@ -9,10 +9,11 @@ from io import StringIO
 
 from input import args
 
-from command.init     import init   as mepo_init
-from command.clone    import clone  as mepo_clone
-from command.list     import list   as mepo_list
-from command.status   import status as mepo_status
+from command.init    import init    as mepo_init
+from command.clone   import clone   as mepo_clone
+from command.list    import list    as mepo_list
+from command.status  import status  as mepo_status
+from command.compare import compare as mepo_compare
 
 class TestMepoCommands(unittest.TestCase):
 
@@ -65,6 +66,14 @@ class TestMepoCommands(unittest.TestCase):
         mepo_status.run(args)
         sys.stdout = sys.__stdout__
         with open(os.path.join(self.__class__.output_dir, 'status_output.txt'), 'r') as fin:
+            saved_output = fin.read()
+        self.assertEqual(output.getvalue(), saved_output)
+
+    def test_compare_no_change(self):
+        sys.stdout = output = StringIO()
+        mepo_compare.run(args)
+        sys.stdout = sys.__stdout__
+        with open(os.path.join(self.__class__.output_dir, 'compare_no_change.txt'), 'r') as fin:
             saved_output = fin.read()
         self.assertEqual(output.getvalue(), saved_output)
 


### PR DESCRIPTION
With this PR, one can do:
```
mepo init --style <foo>
```
or:
```
mepo clone --style <foo> URL
```
and the `--style <foo>` can be one of `naked`, `prefix`, and `postfix` with the default as `prefix` as that is the current dominant style.

These styles are `prefix` leads to `@subrepo`, `postfix` leads to `subrepo@`, and `naked` leads to `subrepo` when `mepo` clones the subrepos