### PR TITLE
Add mepo config capability 

### DIFF
--- a/etc/mepoconfig-example
+++ b/etc/mepoconfig-example
@@ -1,0 +1,42 @@
+# This is a skeleton example of a .mepoconfig file
+#
+# .mepoconfig is a config file a la gitconfig with sections and options.
+#
+# Currently, .mepoconfig files recognize two sections: [init] and [alias]
+#
+# =======================================================================
+#
+# [init] Section
+#
+#   The init section currently recognizes one option, style.
+#   This has three allowed values: naked, postfix, prefix
+#
+#   So if you have:
+#
+#     [init]
+#     style = postfix
+#
+#   This is equivalent to doing:
+#
+#     mepo init --style postfix
+#
+#   or when running with mepo clone:
+#
+#     mepo clone --style postfix
+#
+# =======================================================================
+#
+# [alias] Section
+#
+#   The [alias] Section is used to make aliases of mepo commands. For
+#   example this:
+#
+#     [alias]
+#     st = status
+#
+#   lets one run "mepo st" as an alias to "mepo status"
+#
+#   Note: Due to lack of skill of the developer and limitations in Argparse,
+#         you can only alias mepo primary commands and not "subcommands" or
+#         "options". So you can have an alias for "commit" and for "branch",
+#         but you can't do an option for "commit -m" or "branch create".

--- a/mepo.d/cmdline/config_parser.py
+++ b/mepo.d/cmdline/config_parser.py
@@ -1,0 +1,83 @@
+import argparse
+import textwrap
+
+class MepoConfigArgParser(object):
+
+    def __init__(self, config):
+        self.config = config.add_subparsers()
+        self.config.title = 'mepo config sub-commands'
+        self.config.dest = 'mepo_config_cmd'
+        self.config.required = True
+        self.__get()
+        self.__set()
+        self.__delete()
+        self.__print()
+
+    def __get(self):
+        get = self.config.add_parser(
+            'get',
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+            description = textwrap.dedent('''\
+                Get config <entry> in .mepoconfig.
+
+                Note this uses gitconfig style where <entry> is
+                of the form "section.option" So to get something like:
+
+                    [alias]
+                    st = status
+
+                You would run "mepo config get alias.st"
+                '''))
+        get.add_argument(
+            'entry',
+            metavar = 'entry',
+            help = 'Entry to display.')
+
+    def __set(self):
+        set = self.config.add_parser(
+            'set',
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+            description = textwrap.dedent('''\
+                Set config <entry> to <value> in .mepoconfig.
+
+                Note this uses gitconfig style where <entry> is
+                of the form "section.option" So to set something like:
+
+                    [alias]
+                    st = status
+
+                You would run "mepo config set alias.st status"
+                '''))
+        set.add_argument(
+            'entry',
+            metavar = 'entry',
+            help = 'Entry to set.')
+        set.add_argument(
+            'value',
+            metavar = 'value',
+            help = 'Value to set entry to.')
+
+    def __delete(self):
+        delete = self.config.add_parser(
+            'delete',
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+            description = textwrap.dedent('''\
+                Delete config <entry> in .mepoconfig.
+
+                Note this uses gitconfig style where <entry> is
+                of the form "section.option" So to delete something like:
+
+                    [alias]
+                    st = status
+
+                You would run "mepo config delete alias.st"
+                '''))
+        delete.add_argument(
+            'entry',
+            metavar = 'entry',
+            help = 'Entry to delete.')
+
+    def __print(self):
+        print = self.config.add_parser(
+            'print',
+            description = 'Print contents of .mepoconfig')

--- a/mepo.d/cmdline/parser.py
+++ b/mepo.d/cmdline/parser.py
@@ -3,6 +3,7 @@ import argparse
 from cmdline.branch_parser import MepoBranchArgParser
 from cmdline.stash_parser  import MepoStashArgParser
 from cmdline.tag_parser    import MepoTagArgParser
+from utilities             import mepoconfig
 
 class MepoArgParser(object):
 
@@ -45,7 +46,8 @@ class MepoArgParser(object):
     def __init(self):
         init = self.subparsers.add_parser(
             'init',
-            description = 'Initialize mepo based on <config-file>')
+            description = 'Initialize mepo based on <config-file>',
+            aliases=mepoconfig.get_alias('init'))
         init.add_argument(
             '--config',
             metavar = 'config-file',
@@ -56,14 +58,15 @@ class MepoArgParser(object):
             '--style',
             metavar = 'style-type',
             nargs = '?',
-            default = 'prefix',
+            default = None,
             choices = ['naked', 'prefix','postfix'],
-            help = 'Style of directory file, default: %(default)s, allowed options: %(choices)s')
+            help = 'Style of directory file, default: prefix, allowed options: %(choices)s')
 
     def __clone(self):
         clone = self.subparsers.add_parser(
             'clone',
-            description = "Clone repositories.")
+            description = "Clone repositories.",
+            aliases=mepoconfig.get_alias('clone'))
         clone.add_argument(
             'repo_url',
             metavar = 'URL',
@@ -91,29 +94,33 @@ class MepoArgParser(object):
             '--style',
             metavar = 'style-type',
             nargs = '?',
-            default = 'prefix',
+            default = None,
             choices = ['naked', 'prefix','postfix'],
-            help = 'Style of directory file, default: %(default)s, allowed options: %(choices)s (ignored if init already called)')
+            help = 'Style of directory file, default: prefix, allowed options: %(choices)s (ignored if init already called)')
 
     def __list(self):
         listcomps = self.subparsers.add_parser(
             'list',
-            description = 'List all components that are being tracked')
+            description = 'List all components that are being tracked',
+            aliases=mepoconfig.get_alias('list'))
 
     def __status(self):
         status = self.subparsers.add_parser(
             'status',
-            description = 'Check current status of all components')
+            description = 'Check current status of all components',
+            aliases=mepoconfig.get_alias('status'))
 
     def __restore_state(self):
         restore_state = self.subparsers.add_parser(
             'restore-state',
-            description = 'Restores all components to the last saved state.')
+            description = 'Restores all components to the last saved state.',
+            aliases=mepoconfig.get_alias('restore-state'))
 
     def __diff(self):
         diff = self.subparsers.add_parser(
             'diff',
-            description = 'Diff all components')
+            description = 'Diff all components',
+            aliases=mepoconfig.get_alias('diff'))
         diff.add_argument(
             '--name-only',
             action = 'store_true',
@@ -133,7 +140,8 @@ class MepoArgParser(object):
             'checkout',
             description = 'Switch to branch <branch-name> in component <comp-name>. '
             'Specifying -b causes the branch <branch-name> to be created in '
-            'the specified component(s).')
+            'the specified component(s).',
+            aliases=mepoconfig.get_alias('checkout'))
         checkout.add_argument('branch_name', metavar = 'branch-name')
         checkout.add_argument('comp_name', metavar = 'comp-name', nargs = '+')
         checkout.add_argument('-b', action = 'store_true', help = 'create the branch')
@@ -142,7 +150,8 @@ class MepoArgParser(object):
     def __checkout_if_exists(self):
         checkout_if_exists = self.subparsers.add_parser(
             'checkout-if-exists',
-            description = 'Switch to branch <branch-name> in any component where it is present. ')
+            description = 'Switch to branch <branch-name> in any component where it is present. ',
+            aliases=mepoconfig.get_alias('checkout-if-exists'))
         checkout_if_exists.add_argument('branch_name', metavar = 'branch-name')
         checkout_if_exists.add_argument('--quiet', '-q', action = 'store_true', help = 'Suppress prints')
         checkout_if_exists.add_argument('--dry-run','-n', action = 'store_true', help = 'Dry-run only (lists repos where branch exists)')
@@ -151,7 +160,8 @@ class MepoArgParser(object):
         fetch = self.subparsers.add_parser(
             'fetch',
             description = 'Download objects and refs from in component <comp-name>. '
-            'Specifying --all causes all remotes to be fetched.')
+            'Specifying --all causes all remotes to be fetched.',
+            aliases=mepoconfig.get_alias('fetch'))
         fetch.add_argument('comp_name', metavar = 'comp-name', nargs = '+')
         fetch.add_argument('--all', action = 'store_true', help = 'Fetch all remotes.')
         fetch.add_argument('--prune','-p', action = 'store_true', help = 'Prune remote branches.')
@@ -162,7 +172,8 @@ class MepoArgParser(object):
         fetch_all = self.subparsers.add_parser(
             'fetch-all',
             description = 'Download objects and refs from all components. '
-            'Specifying --all causes all remotes to be fetched.')
+            'Specifying --all causes all remotes to be fetched.',
+            aliases=mepoconfig.get_alias('fetch-all'))
         fetch_all.add_argument('--all', action = 'store_true', help = 'Fetch all remotes.')
         fetch_all.add_argument('--prune','-p', action = 'store_true', help = 'Prune remote branches.')
         fetch_all.add_argument('--tags','-t', action = 'store_true', help = 'Fetch tags.')
@@ -171,56 +182,65 @@ class MepoArgParser(object):
     def __branch(self):
         branch = self.subparsers.add_parser(
             'branch',
-            description = "Runs branch commands.")
+            description = "Runs branch commands.",
+            aliases=mepoconfig.get_alias('branch'))
         MepoBranchArgParser(branch)
 
     def __stash(self):
         stash = self.subparsers.add_parser(
             'stash',
-            description = "Runs stash commands.")
+            description = "Runs stash commands.",
+            aliases=mepoconfig.get_alias('stash'))
         MepoStashArgParser(stash)
 
     def __tag(self):
         tag = self.subparsers.add_parser(
             'tag',
-            description = "Runs tag commands.")
+            description = "Runs tag commands.",
+            aliases=mepoconfig.get_alias('tag'))
         MepoTagArgParser(tag)
 
     def __develop(self):
         develop = self.subparsers.add_parser(
             'develop',
-            description = "Checkout current version of 'develop' branches of specified components")
+            description = "Checkout current version of 'develop' branches of specified components",
+            aliases=mepoconfig.get_alias('develop'))
         develop.add_argument('comp_name', metavar = 'comp-name', nargs = '+', default = None)
         develop.add_argument('--quiet', '-q', action = 'store_true', help = 'Suppress prints')
 
     def __pull(self):
         pull = self.subparsers.add_parser(
             'pull',
-            description = "Pull branches of specified components")
+            description = "Pull branches of specified components",
+            aliases=mepoconfig.get_alias('pull'))
         pull.add_argument('comp_name', metavar = 'comp-name', nargs = '+', default = None)
 
     def __pull_all(self):
         pull_all = self.subparsers.add_parser(
             'pull-all',
-            description = "Pull branches of all components (only those in non-detached HEAD state)")
+            description = "Pull branches of all components (only those in non-detached HEAD state)",
+            aliases=mepoconfig.get_alias('pull-all'))
 
     def __compare(self):
         compare = self.subparsers.add_parser(
             'compare',
-            description = 'Compare current and original states of all components')
+            description = 'Compare current and original states of all components',
+            aliases=mepoconfig.get_alias('compare'))
 
     def __whereis(self):
         whereis = self.subparsers.add_parser(
             'whereis',
             description = 'Get the location of component <comp-name> '
             'relative to my current location. If <comp-name> is not present, '
-            'get the relative locations of ALL components.')
+            'get the relative locations of ALL components.',
+            aliases=mepoconfig.get_alias('whereis'))
         whereis.add_argument('comp_name', metavar = 'comp-name', nargs = '?', default = None)
 
     def __stage(self):
         stage = self.subparsers.add_parser(
             'stage',
-            description = 'Stage modified & untracked files in the specified component(s)')
+            description = 'Stage modified & untracked files in the specified component(s)',
+            aliases=mepoconfig.get_alias('stage'))
         stage.add_argument(
             '--untracked',
             action = 'store_true',
@@ -235,7 +255,8 @@ class MepoArgParser(object):
         unstage = self.subparsers.add_parser(
             'unstage',
             description = 'Un-stage staged files. '
-            'If a component is specified, files are un-staged only for that component.')
+            'If a component is specified, files are un-staged only for that component.',
+            aliases=mepoconfig.get_alias('unstage'))
         unstage.add_argument(
             'comp_name',
             metavar = 'comp-name',
@@ -246,7 +267,8 @@ class MepoArgParser(object):
     def __commit(self):
         commit = self.subparsers.add_parser(
             'commit',
-            description = 'Commit staged files in the specified components')
+            description = 'Commit staged files in the specified components',
+            aliases=mepoconfig.get_alias('commit'))
         commit.add_argument('-a', '--all', action = 'store_true', help = 'stage all tracked files and then commit')
         commit.add_argument('-m', '--message', type=str, metavar = 'message', default=None)
         commit.add_argument(
@@ -258,7 +280,8 @@ class MepoArgParser(object):
     def __push(self):
         push = self.subparsers.add_parser(
             'push',
-            description = 'Push local commits or tags to remote')
+            description = 'Push local commits or tags to remote',
+            aliases=mepoconfig.get_alias('push'))
         push.add_argument(
             '--tags',
             action = 'store_true',
@@ -272,7 +295,8 @@ class MepoArgParser(object):
     def __save(self):
         save = self.subparsers.add_parser(
             'save',
-            description = 'Save current state in a yaml config file')
+            description = 'Save current state in a yaml config file',
+            aliases=mepoconfig.get_alias('save'))
         save.add_argument(
             'config_file',
             metavar = 'config-file',

--- a/mepo.d/cmdline/parser.py
+++ b/mepo.d/cmdline/parser.py
@@ -3,6 +3,7 @@ import argparse
 from cmdline.branch_parser import MepoBranchArgParser
 from cmdline.stash_parser  import MepoStashArgParser
 from cmdline.tag_parser    import MepoTagArgParser
+from cmdline.config_parser import MepoConfigArgParser
 from utilities             import mepoconfig
 
 class MepoArgParser(object):
@@ -41,6 +42,7 @@ class MepoArgParser(object):
         self.__commit()
         self.__push()
         self.__save()
+        self.__config()
         return self.parser.parse_args()
 
     def __init(self):
@@ -303,3 +305,10 @@ class MepoArgParser(object):
             nargs = '?',
             default = 'components-new.yaml',
             help = 'default: %(default)s')
+
+    def __config(self):
+        config = self.subparsers.add_parser(
+            'config',
+            description = "Runs config commands.",
+            aliases=mepoconfig.get_command_alias('config'))
+        MepoConfigArgParser(config)

--- a/mepo.d/cmdline/parser.py
+++ b/mepo.d/cmdline/parser.py
@@ -47,7 +47,7 @@ class MepoArgParser(object):
         init = self.subparsers.add_parser(
             'init',
             description = 'Initialize mepo based on <config-file>',
-            aliases=mepoconfig.get_alias('init'))
+            aliases=mepoconfig.get_command_alias('init'))
         init.add_argument(
             '--config',
             metavar = 'config-file',
@@ -66,7 +66,7 @@ class MepoArgParser(object):
         clone = self.subparsers.add_parser(
             'clone',
             description = "Clone repositories.",
-            aliases=mepoconfig.get_alias('clone'))
+            aliases=mepoconfig.get_command_alias('clone'))
         clone.add_argument(
             'repo_url',
             metavar = 'URL',
@@ -102,25 +102,25 @@ class MepoArgParser(object):
         listcomps = self.subparsers.add_parser(
             'list',
             description = 'List all components that are being tracked',
-            aliases=mepoconfig.get_alias('list'))
+            aliases=mepoconfig.get_command_alias('list'))
 
     def __status(self):
         status = self.subparsers.add_parser(
             'status',
             description = 'Check current status of all components',
-            aliases=mepoconfig.get_alias('status'))
+            aliases=mepoconfig.get_command_alias('status'))
 
     def __restore_state(self):
         restore_state = self.subparsers.add_parser(
             'restore-state',
             description = 'Restores all components to the last saved state.',
-            aliases=mepoconfig.get_alias('restore-state'))
+            aliases=mepoconfig.get_command_alias('restore-state'))
 
     def __diff(self):
         diff = self.subparsers.add_parser(
             'diff',
             description = 'Diff all components',
-            aliases=mepoconfig.get_alias('diff'))
+            aliases=mepoconfig.get_command_alias('diff'))
         diff.add_argument(
             '--name-only',
             action = 'store_true',
@@ -141,7 +141,7 @@ class MepoArgParser(object):
             description = 'Switch to branch <branch-name> in component <comp-name>. '
             'Specifying -b causes the branch <branch-name> to be created in '
             'the specified component(s).',
-            aliases=mepoconfig.get_alias('checkout'))
+            aliases=mepoconfig.get_command_alias('checkout'))
         checkout.add_argument('branch_name', metavar = 'branch-name')
         checkout.add_argument('comp_name', metavar = 'comp-name', nargs = '+')
         checkout.add_argument('-b', action = 'store_true', help = 'create the branch')
@@ -151,7 +151,7 @@ class MepoArgParser(object):
         checkout_if_exists = self.subparsers.add_parser(
             'checkout-if-exists',
             description = 'Switch to branch <branch-name> in any component where it is present. ',
-            aliases=mepoconfig.get_alias('checkout-if-exists'))
+            aliases=mepoconfig.get_command_alias('checkout-if-exists'))
         checkout_if_exists.add_argument('branch_name', metavar = 'branch-name')
         checkout_if_exists.add_argument('--quiet', '-q', action = 'store_true', help = 'Suppress prints')
         checkout_if_exists.add_argument('--dry-run','-n', action = 'store_true', help = 'Dry-run only (lists repos where branch exists)')
@@ -161,7 +161,7 @@ class MepoArgParser(object):
             'fetch',
             description = 'Download objects and refs from in component <comp-name>. '
             'Specifying --all causes all remotes to be fetched.',
-            aliases=mepoconfig.get_alias('fetch'))
+            aliases=mepoconfig.get_command_alias('fetch'))
         fetch.add_argument('comp_name', metavar = 'comp-name', nargs = '+')
         fetch.add_argument('--all', action = 'store_true', help = 'Fetch all remotes.')
         fetch.add_argument('--prune','-p', action = 'store_true', help = 'Prune remote branches.')
@@ -173,7 +173,7 @@ class MepoArgParser(object):
             'fetch-all',
             description = 'Download objects and refs from all components. '
             'Specifying --all causes all remotes to be fetched.',
-            aliases=mepoconfig.get_alias('fetch-all'))
+            aliases=mepoconfig.get_command_alias('fetch-all'))
         fetch_all.add_argument('--all', action = 'store_true', help = 'Fetch all remotes.')
         fetch_all.add_argument('--prune','-p', action = 'store_true', help = 'Prune remote branches.')
         fetch_all.add_argument('--tags','-t', action = 'store_true', help = 'Fetch tags.')
@@ -183,28 +183,28 @@ class MepoArgParser(object):
         branch = self.subparsers.add_parser(
             'branch',
             description = "Runs branch commands.",
-            aliases=mepoconfig.get_alias('branch'))
+            aliases=mepoconfig.get_command_alias('branch'))
         MepoBranchArgParser(branch)
 
     def __stash(self):
         stash = self.subparsers.add_parser(
             'stash',
             description = "Runs stash commands.",
-            aliases=mepoconfig.get_alias('stash'))
+            aliases=mepoconfig.get_command_alias('stash'))
         MepoStashArgParser(stash)
 
     def __tag(self):
         tag = self.subparsers.add_parser(
             'tag',
             description = "Runs tag commands.",
-            aliases=mepoconfig.get_alias('tag'))
+            aliases=mepoconfig.get_command_alias('tag'))
         MepoTagArgParser(tag)
 
     def __develop(self):
         develop = self.subparsers.add_parser(
             'develop',
             description = "Checkout current version of 'develop' branches of specified components",
-            aliases=mepoconfig.get_alias('develop'))
+            aliases=mepoconfig.get_command_alias('develop'))
         develop.add_argument('comp_name', metavar = 'comp-name', nargs = '+', default = None)
         develop.add_argument('--quiet', '-q', action = 'store_true', help = 'Suppress prints')
 
@@ -212,20 +212,20 @@ class MepoArgParser(object):
         pull = self.subparsers.add_parser(
             'pull',
             description = "Pull branches of specified components",
-            aliases=mepoconfig.get_alias('pull'))
+            aliases=mepoconfig.get_command_alias('pull'))
         pull.add_argument('comp_name', metavar = 'comp-name', nargs = '+', default = None)
 
     def __pull_all(self):
         pull_all = self.subparsers.add_parser(
             'pull-all',
             description = "Pull branches of all components (only those in non-detached HEAD state)",
-            aliases=mepoconfig.get_alias('pull-all'))
+            aliases=mepoconfig.get_command_alias('pull-all'))
 
     def __compare(self):
         compare = self.subparsers.add_parser(
             'compare',
             description = 'Compare current and original states of all components',
-            aliases=mepoconfig.get_alias('compare'))
+            aliases=mepoconfig.get_command_alias('compare'))
 
     def __whereis(self):
         whereis = self.subparsers.add_parser(
@@ -233,14 +233,14 @@ class MepoArgParser(object):
             description = 'Get the location of component <comp-name> '
             'relative to my current location. If <comp-name> is not present, '
             'get the relative locations of ALL components.',
-            aliases=mepoconfig.get_alias('whereis'))
+            aliases=mepoconfig.get_command_alias('whereis'))
         whereis.add_argument('comp_name', metavar = 'comp-name', nargs = '?', default = None)
 
     def __stage(self):
         stage = self.subparsers.add_parser(
             'stage',
             description = 'Stage modified & untracked files in the specified component(s)',
-            aliases=mepoconfig.get_alias('stage'))
+            aliases=mepoconfig.get_command_alias('stage'))
         stage.add_argument(
             '--untracked',
             action = 'store_true',
@@ -256,7 +256,7 @@ class MepoArgParser(object):
             'unstage',
             description = 'Un-stage staged files. '
             'If a component is specified, files are un-staged only for that component.',
-            aliases=mepoconfig.get_alias('unstage'))
+            aliases=mepoconfig.get_command_alias('unstage'))
         unstage.add_argument(
             'comp_name',
             metavar = 'comp-name',
@@ -268,7 +268,7 @@ class MepoArgParser(object):
         commit = self.subparsers.add_parser(
             'commit',
             description = 'Commit staged files in the specified components',
-            aliases=mepoconfig.get_alias('commit'))
+            aliases=mepoconfig.get_command_alias('commit'))
         commit.add_argument('-a', '--all', action = 'store_true', help = 'stage all tracked files and then commit')
         commit.add_argument('-m', '--message', type=str, metavar = 'message', default=None)
         commit.add_argument(
@@ -281,7 +281,7 @@ class MepoArgParser(object):
         push = self.subparsers.add_parser(
             'push',
             description = 'Push local commits or tags to remote',
-            aliases=mepoconfig.get_alias('push'))
+            aliases=mepoconfig.get_command_alias('push'))
         push.add_argument(
             '--tags',
             action = 'store_true',
@@ -296,7 +296,7 @@ class MepoArgParser(object):
         save = self.subparsers.add_parser(
             'save',
             description = 'Save current state in a yaml config file',
-            aliases=mepoconfig.get_alias('save'))
+            aliases=mepoconfig.get_command_alias('save'))
         save.add_argument(
             'config_file',
             metavar = 'config-file',

--- a/mepo.d/command/command.py
+++ b/mepo.d/command/command.py
@@ -1,7 +1,8 @@
 from importlib import import_module
+from utilities import mepoconfig
 
 def run(args):
-    mepo_cmd = args.mepo_cmd
+    mepo_cmd = mepoconfig.get_alias_command(args.mepo_cmd)
 
     # Load the module containing the 'run' method of specified mepo command
     cmd_module = import_module('command.{}.{}'.format(mepo_cmd, mepo_cmd))

--- a/mepo.d/command/config/config.py
+++ b/mepo.d/command/config/config.py
@@ -1,0 +1,17 @@
+import subprocess as sp
+
+from state.state import MepoState
+
+from command.config.get    import get
+from command.config.set    import set
+from command.config.delete import delete
+from command.config.print  import print
+
+def run(args):
+    d = {
+        'get': get,
+        'set': set,
+        'delete': delete,
+        'print': print
+    }
+    d[args.mepo_config_cmd].run(args)

--- a/mepo.d/command/config/delete/delete.py
+++ b/mepo.d/command/config/delete/delete.py
@@ -1,0 +1,6 @@
+from utilities import mepoconfig
+
+def run(args):
+    section, option = mepoconfig.split_entry(args.entry)
+    mepoconfig.remove_option(section, option)
+    mepoconfig.write()

--- a/mepo.d/command/config/get/get.py
+++ b/mepo.d/command/config/get/get.py
@@ -1,0 +1,13 @@
+from utilities import mepoconfig
+
+def run(args):
+    section, option = mepoconfig.split_entry(args.entry)
+    if not mepoconfig.has_section(section):
+        raise Exception(f'Section [{section}] does not exist in .mepoconfig')
+    if not mepoconfig.has_option(section, option):
+        raise Exception(f'Option [{option}] does not exist in section [{section}] in .mepoconfig')
+    value = mepoconfig.get(section, option)
+    print(f'''
+    [{section}]
+    {option} = {value}
+    ''')

--- a/mepo.d/command/config/print/print.py
+++ b/mepo.d/command/config/print/print.py
@@ -1,0 +1,4 @@
+from utilities import mepoconfig
+
+def run(args):
+    mepoconfig.print()

--- a/mepo.d/command/config/set/set.py
+++ b/mepo.d/command/config/set/set.py
@@ -1,0 +1,7 @@
+from utilities import mepoconfig
+
+def run(args):
+    section, option = mepoconfig.split_entry(args.entry)
+    value = args.value
+    mepoconfig.set(section, option, value)
+    mepoconfig.write()

--- a/mepo.d/command/init/init.py
+++ b/mepo.d/command/init/init.py
@@ -1,5 +1,19 @@
 from state.state import MepoState
+from utilities import mepoconfig
 
 def run(args):
-    allcomps = MepoState.initialize(args.config,args.style)
-    print(f'Initializing mepo using {args.config} with {args.style} style.')
+    if args.style:
+        style = args.style
+    elif mepoconfig.has_option('init','style'):
+        allowed_styles = ['naked','prefix','postfix']
+        style = mepoconfig.get('init','style')
+        if style not in allowed_styles:
+            raise Exception(f'Detected style [{style}] from .mepoconfig is not an allowed style: {allowed_styles}')
+        else:
+            print(f'Found style [{style}] in .mepoconfig')
+    else:
+        style = 'prefix'
+
+    allcomps = MepoState.initialize(args.config,style)
+
+    print(f'Initializing mepo using {args.config} with {style} style.')

--- a/mepo.d/state/component.py
+++ b/mepo.d/state/component.py
@@ -2,7 +2,7 @@ import os
 import textwrap
 from collections import namedtuple
 from utilities.version import MepoVersion
-from utilities import shellcmd
+from utilities import shellcmd, mepoconfig
 from urllib.parse import urlparse
 
 # This will be used to store the "final nodes" from each subrepo

--- a/mepo.d/utilities/mepoconfig.py
+++ b/mepo.d/utilities/mepoconfig.py
@@ -28,7 +28,7 @@ def get(section, option):
     mepoconfig.read(mepoconfig_file)
     return mepoconfig.get(section, option)
 
-def get_alias(command):
+def get_command_alias(command):
     output = []
     mepoconfig = configparser.ConfigParser()
     mepoconfig.read(mepoconfig_file)

--- a/mepo.d/utilities/mepoconfig.py
+++ b/mepo.d/utilities/mepoconfig.py
@@ -1,49 +1,63 @@
 import configparser
 import os
+import sys
 
-mepoconfig_file = os.path.expanduser('~/.mepoconfig')
+config_file = os.path.expanduser('~/.mepoconfig')
+config = configparser.ConfigParser()
+config.read(config_file)
+
+def split_entry(entry):
+    entry_list = entry.split('.')
+    if len(entry_list) != 2:
+        raise Exception(f'Invalid entry [{entry}]. Must be of form section.option, e.g., "alias.st"')
+    section = entry_list[0]
+    option = entry_list[1]
+    return section, option
+
+def write():
+    with open(config_file,'w') as fp:
+        config.write(fp)
 
 def print_sections():
-    mepoconfig = configparser.ConfigParser()
-    mepoconfig.read(mepoconfig_file)
-    print(mepoconfig.sections())
+    print(config.sections())
 
 def print_options(section):
-    mepoconfig = configparser.ConfigParser()
-    mepoconfig.read(mepoconfig_file)
-    print(mepoconfig.options(section))
+    print(config.options(section))
+
+def print():
+    config.write(sys.stdout)
 
 def has_section(section):
-    mepoconfig = configparser.ConfigParser()
-    mepoconfig.read(mepoconfig_file)
-    return mepoconfig.has_section(section)
+    return config.has_section(section)
 
 def has_option(section, option):
-    mepoconfig = configparser.ConfigParser()
-    mepoconfig.read(mepoconfig_file)
-    return mepoconfig.has_option(section, option)
+    return config.has_option(section, option)
 
 def get(section, option):
-    mepoconfig = configparser.ConfigParser()
-    mepoconfig.read(mepoconfig_file)
-    return mepoconfig.get(section, option)
+    return config[section][option]
+
+def remove_option(section, option):
+    config.remove_option(section, option)
+    if not config[section]:
+        config.remove_section(section)
+
+def set(section, option, value):
+    if not has_section(section):
+        config[section] = {}
+    config[section][option] = value
 
 def get_command_alias(command):
     output = []
-    mepoconfig = configparser.ConfigParser()
-    mepoconfig.read(mepoconfig_file)
     if has_section('alias'):
-        for key,value in mepoconfig.items('alias'):
+        for key,value in config.items('alias'):
             if value == command:
                 output.append(key)
     return output
 
 def get_alias_command(alias):
-    mepoconfig = configparser.ConfigParser()
-    mepoconfig.read(mepoconfig_file)
     command = alias
     if has_section('alias'):
-        for key,value in mepoconfig.items('alias'):
+        for key,value in config.items('alias'):
             if key == alias:
                 command = value
     return command

--- a/mepo.d/utilities/mepoconfig.py
+++ b/mepo.d/utilities/mepoconfig.py
@@ -1,0 +1,49 @@
+import configparser
+import os
+
+mepoconfig_file = os.path.expanduser('~/.mepoconfig')
+
+def print_sections():
+    mepoconfig = configparser.ConfigParser()
+    mepoconfig.read(mepoconfig_file)
+    print(mepoconfig.sections())
+
+def print_options(section):
+    mepoconfig = configparser.ConfigParser()
+    mepoconfig.read(mepoconfig_file)
+    print(mepoconfig.options(section))
+
+def has_section(section):
+    mepoconfig = configparser.ConfigParser()
+    mepoconfig.read(mepoconfig_file)
+    return mepoconfig.has_section(section)
+
+def has_option(section, option):
+    mepoconfig = configparser.ConfigParser()
+    mepoconfig.read(mepoconfig_file)
+    return mepoconfig.has_option(section, option)
+
+def get(section, option):
+    mepoconfig = configparser.ConfigParser()
+    mepoconfig.read(mepoconfig_file)
+    return mepoconfig.get(section, option)
+
+def get_alias(command):
+    output = []
+    mepoconfig = configparser.ConfigParser()
+    mepoconfig.read(mepoconfig_file)
+    if has_section('alias'):
+        for key,value in mepoconfig.items('alias'):
+            if value == command:
+                output.append(key)
+    return output
+
+def get_alias_command(alias):
+    mepoconfig = configparser.ConfigParser()
+    mepoconfig.read(mepoconfig_file)
+    command = alias
+    if has_section('alias'):
+        for key,value in mepoconfig.items('alias'):
+            if key == alias:
+                command = value
+    return command


### PR DESCRIPTION
Closes #139 

This isn't perfect, but it's a first blush at a mepoconfig capability. Thanks to @JulesKouatchou for inspiration.

To wit, this PR adds support for a `~/.mepoconfig` file and adds a new command:
```console
usage: mepo config [-h] {get,set,delete,print} ...

Runs config commands.

positional arguments:
  {get,set,delete,print}
```
which has four subcommands. I tried to make it like `git-config` in many respects, but I'm not that good at Python and Argparse so it's like many other mepo commands with subcommands. 

***NOTE***: This capability is *not* as powerful as `git-config` is. For example, this:
```
[alias]
ci = commit
```
is allowed. But this:
```
[alias]
cm = commit -m
```
is not. This is a limitation of what I could do in Python and with Argparse. You can make an alias of a command, but not any of the options of commands. And I couldn't figure out how to do aliases with subcommands. 

---

Note for @amdasilva, for the "style" the entry would be:
```
[init]
style = postfix
```
It's in the `[init]` section because technically that is where the command is used. It's just that `mepo clone` "piggybacks" on `init` so that if you do:
```
mepo clone --style naked
```
it's actually doing:
```
mepo init --style naked
mepo clone
```

---

## Examples

### mepo config print
To print the `.mepoconfig` file:
```
mepo config print
```

### mepo config set
To set a value in the `.mepoconfig` file:
```
mepo set alias.st status
```
In "gitconfig" style, this is equivalent to adding to the file:
```console
[alias]
st = status
```

### mepo config get
This command gets `section.option`:
```console
❯ mepo config get alias.st

    [alias]
    st = status
```

### mepo config delete
This command deletes the `section.option` from the file