### PR TITLE
Attempt to fix mepo status and compare tag weirdness

### DIFF
--- a/mepo.d/command/compare/compare.py
+++ b/mepo.d/command/compare/compare.py
@@ -1,6 +1,6 @@
 from state.state import MepoState
 from utilities import colors
-from utilities.version import version_to_string
+from utilities.version import version_to_string, sanitize_version_string
 from repository.git import GitRepository
 from shutil import get_terminal_size
 
@@ -47,52 +47,3 @@ def print_cmp(name, orig, curr, name_width, orig_width):
         print(FMT2.format(name_blank, '...', curr))
     else:
         print(FMT0.format(name, orig, curr))
-
-def sanitize_version_string(orig,curr,git):
-    '''
-    This routine tries to figure out if two tags are the same.
-
-    The issue is that git sometimes returns the "wrong" tag in
-    the mepo sense. mepo might have checked out tag v1.0.0 but
-    if that commit is also tagged with foo, then sometimes mepo
-    will say that things have changed because it thinks it's on
-    foo.
-    '''
-
-    # The trick below only works on tags (I think), so
-    # if not a tag, just do nothing for now
-    is_tag = '(t)'
-
-    # We pass in space-delimited strings that are:
-    #  'type version dh'
-    # So let's split into lists...
-    orig_list = orig.split()
-    curr_list = curr.split()
-
-    # Then pull the types...
-    orig_type = orig_list[0]
-    curr_type = curr_list[0]
-
-    # Now if a type...
-    if orig_type == is_tag and curr_type == is_tag:
-
-        # Pull out the version string...
-        orig_ver = orig_list[1]
-        curr_ver = curr_list[1]
-
-        # Use rev-list to get the hash of the tag...
-        orig_rev = git.rev_list(orig_ver)
-        curr_rev = git.rev_list(curr_ver)
-
-        # If they are identical...
-        if orig_rev == curr_rev:
-
-            # Replace the curr version with the original to make
-            # mepo happy...
-            curr_list[curr_list.index(curr_ver)] = orig_ver
-
-            # And then remake the curr string
-            curr = ' '.join(curr_list)
-
-    # And return curr
-    return curr

--- a/mepo.d/command/compare/compare.py
+++ b/mepo.d/command/compare/compare.py
@@ -15,6 +15,10 @@ def run(args):
         git = GitRepository(comp.remote, comp.local)
         curr_ver = version_to_string(git.get_version())
         orig_ver = version_to_string(comp.version)
+
+        # This command is to try and work with git tag oddities
+        curr_ver = sanitize_version_string(orig_ver,curr_ver,git)
+
         print_cmp(comp.name, orig_ver, curr_ver, max_namelen, max_origlen)
 
 def print_header(max_namelen, max_origlen):
@@ -43,3 +47,52 @@ def print_cmp(name, orig, curr, name_width, orig_width):
         print(FMT2.format(name_blank, '...', curr))
     else:
         print(FMT0.format(name, orig, curr))
+
+def sanitize_version_string(orig,curr,git):
+    '''
+    This routine tries to figure out if two tags are the same.
+
+    The issue is that git sometimes returns the "wrong" tag in
+    the mepo sense. mepo might have checked out tag v1.0.0 but
+    if that commit is also tagged with foo, then sometimes mepo
+    will say that things have changed because it thinks it's on
+    foo.
+    '''
+
+    # The trick below only works on tags (I think), so
+    # if not a tag, just do nothing for now
+    is_tag = '(t)'
+
+    # We pass in space-delimited strings that are:
+    #  'type version dh'
+    # So let's split into lists...
+    orig_list = orig.split()
+    curr_list = curr.split()
+
+    # Then pull the types...
+    orig_type = orig_list[0]
+    curr_type = curr_list[0]
+
+    # Now if a type...
+    if orig_type == is_tag and curr_type == is_tag:
+
+        # Pull out the version string...
+        orig_ver = orig_list[1]
+        curr_ver = curr_list[1]
+
+        # Use rev-list to get the hash of the tag...
+        orig_rev = git.rev_list(orig_ver)
+        curr_rev = git.rev_list(curr_ver)
+
+        # If they are identical...
+        if orig_rev == curr_rev:
+
+            # Replace the curr version with the original to make
+            # mepo happy...
+            curr_list[curr_list.index(curr_ver)] = orig_ver
+
+            # And then remake the curr string
+            curr = ' '.join(curr_list)
+
+    # And return curr
+    return curr

--- a/mepo.d/command/status/status.py
+++ b/mepo.d/command/status/status.py
@@ -5,7 +5,7 @@ import atexit
 
 from state.state import MepoState
 from repository.git import GitRepository
-from utilities.version import version_to_string
+from utilities.version import version_to_string, sanitize_version_string
 from utilities import colors
 
 def run(args):
@@ -55,52 +55,3 @@ def print_status(allcomps, result):
         if (output):
             for line in output.split('\n'):
                 print('   |', line.rstrip())
-
-def sanitize_version_string(orig,curr,git):
-    '''
-    This routine tries to figure out if two tags are the same.
-
-    The issue is that git sometimes returns the "wrong" tag in
-    the mepo sense. mepo might have checked out tag v1.0.0 but
-    if that commit is also tagged with foo, then sometimes mepo
-    will say that things have changed because it thinks it's on
-    foo.
-    '''
-
-    # The trick below only works on tags (I think), so
-    # if not a tag, just do nothing for now
-    is_tag = '(t)'
-
-    # We pass in space-delimited strings that are:
-    #  'type version dh'
-    # So let's split into lists...
-    orig_list = orig.split()
-    curr_list = curr.split()
-
-    # Then pull the types...
-    orig_type = orig_list[0]
-    curr_type = curr_list[0]
-
-    # Now if a type...
-    if orig_type == is_tag and curr_type == is_tag:
-
-        # Pull out the version string...
-        orig_ver = orig_list[1]
-        curr_ver = curr_list[1]
-
-        # Use rev-list to get the hash of the tag...
-        orig_rev = git.rev_list(orig_ver)
-        curr_rev = git.rev_list(curr_ver)
-
-        # If they are identical...
-        if orig_rev == curr_rev:
-
-            # Replace the curr version with the original to make
-            # mepo happy...
-            curr_list[curr_list.index(curr_ver)] = orig_ver
-
-            # And then remake the curr string
-            curr = ' '.join(curr_list)
-
-    # And return curr
-    return curr

--- a/mepo.d/command/status/status.py
+++ b/mepo.d/command/status/status.py
@@ -25,6 +25,11 @@ def check_component_status(comp):
 
     # This can return non "origin/" names for detached head branches
     curr_ver = version_to_string(git.get_version())
+    orig_ver = version_to_string(comp.version)
+
+    # This command is to try and work with git tag oddities
+    curr_ver = sanitize_version_string(orig_ver,curr_ver,git)
+
     return (curr_ver, internal_state_branch_name, git.check_status())
 
 def print_status(allcomps, result):
@@ -32,9 +37,14 @@ def print_status(allcomps, result):
     for index, comp in enumerate(allcomps):
         time.sleep(0.025)
         current_version, internal_state_branch_name, output = result[index]
-        # Check to see if the current tag/branch is the same as the original
-        #if comp.version.name not in internal_state_branch_name:
-        if internal_state_branch_name not in comp.version.name:
+
+        # This should handle tag weirdness...
+        if current_version.split()[1] == comp.version.name:
+            component_name = comp.name
+            width = orig_width
+        # Check to see if the current tag/branch is the same as the original...
+        # if the above check didn't succeed, we are different.
+        elif internal_state_branch_name not in comp.version.name:
             component_name = colors.RED + comp.name + colors.RESET
             width = orig_width + len(colors.RED) + len(colors.RESET)
         else:
@@ -45,3 +55,52 @@ def print_status(allcomps, result):
         if (output):
             for line in output.split('\n'):
                 print('   |', line.rstrip())
+
+def sanitize_version_string(orig,curr,git):
+    '''
+    This routine tries to figure out if two tags are the same.
+
+    The issue is that git sometimes returns the "wrong" tag in
+    the mepo sense. mepo might have checked out tag v1.0.0 but
+    if that commit is also tagged with foo, then sometimes mepo
+    will say that things have changed because it thinks it's on
+    foo.
+    '''
+
+    # The trick below only works on tags (I think), so
+    # if not a tag, just do nothing for now
+    is_tag = '(t)'
+
+    # We pass in space-delimited strings that are:
+    #  'type version dh'
+    # So let's split into lists...
+    orig_list = orig.split()
+    curr_list = curr.split()
+
+    # Then pull the types...
+    orig_type = orig_list[0]
+    curr_type = curr_list[0]
+
+    # Now if a type...
+    if orig_type == is_tag and curr_type == is_tag:
+
+        # Pull out the version string...
+        orig_ver = orig_list[1]
+        curr_ver = curr_list[1]
+
+        # Use rev-list to get the hash of the tag...
+        orig_rev = git.rev_list(orig_ver)
+        curr_rev = git.rev_list(curr_ver)
+
+        # If they are identical...
+        if orig_rev == curr_rev:
+
+            # Replace the curr version with the original to make
+            # mepo happy...
+            curr_list[curr_list.index(curr_ver)] = orig_ver
+
+            # And then remake the curr string
+            curr = ' '.join(curr_list)
+
+    # And return curr
+    return curr

--- a/mepo.d/repository/git.py
+++ b/mepo.d/repository/git.py
@@ -67,6 +67,10 @@ class GitRepository(object):
         cmd = self.__git + ' tag'
         return shellcmd.run(cmd.split(), output=True)
 
+    def rev_list(self, tag):
+        cmd = self.__git + ' rev-list -n 1 {}'.format(tag)
+        return shellcmd.run(cmd.split(), output=True)
+
     def list_stash(self):
         cmd = self.__git + ' stash list'
         return shellcmd.run(cmd.split(), output=True)
@@ -211,7 +215,7 @@ class GitRepository(object):
                     verbose_status = colors.CYAN + "unknown" + colors.RESET + " (please contact mepo maintainer)"
 
                 verbose_status_string = "{file_name:>{file_name_length}}: {verbose_status}".format(
-                        file_name=file_name, file_name_length=max_file_name_length, 
+                        file_name=file_name, file_name_length=max_file_name_length,
                         verbose_status=verbose_status)
                 verbose_output_list.append(verbose_status_string)
 

--- a/mepo.d/utilities/version.py
+++ b/mepo.d/utilities/version.py
@@ -15,3 +15,52 @@ def version_to_string(version):
     else:
         s = f'({version_type}) {version_name}'
     return s
+
+def sanitize_version_string(orig,curr,git):
+    '''
+    This routine tries to figure out if two tags are the same.
+
+    The issue is that git sometimes returns the "wrong" tag in
+    the mepo sense. mepo might have checked out tag v1.0.0 but
+    if that commit is also tagged with foo, then sometimes mepo
+    will say that things have changed because it thinks it's on
+    foo.
+    '''
+
+    # The trick below only works on tags (I think), so
+    # if not a tag, just do nothing for now
+    is_tag = '(t)'
+
+    # We pass in space-delimited strings that are:
+    #  'type version dh'
+    # So let's split into lists...
+    orig_list = orig.split()
+    curr_list = curr.split()
+
+    # Then pull the types...
+    orig_type = orig_list[0]
+    curr_type = curr_list[0]
+
+    # Now if a type...
+    if orig_type == is_tag and curr_type == is_tag:
+
+        # Pull out the version string...
+        orig_ver = orig_list[1]
+        curr_ver = curr_list[1]
+
+        # Use rev-list to get the hash of the tag...
+        orig_rev = git.rev_list(orig_ver)
+        curr_rev = git.rev_list(curr_ver)
+
+        # If they are identical...
+        if orig_rev == curr_rev:
+
+            # Replace the curr version with the original to make
+            # mepo happy...
+            curr_list[curr_list.index(curr_ver)] = orig_ver
+
+            # And then remake the curr string
+            curr = ' '.join(curr_list)
+
+    # And return curr
+    return curr

--- a/mepo.d/utilities/version.py
+++ b/mepo.d/utilities/version.py
@@ -8,7 +8,7 @@ def version_to_string(version):
     version_detached = version[2]
 
     if version_detached: # detached head
-        # We remove the "origin/" from the internal detached branch name 
+        # We remove the "origin/" from the internal detached branch name
         # for clarity in mepo status output
         version_name = version_name.replace('origin/','')
         s = f'({version_type}) {version_name} (DH)'


### PR DESCRIPTION
Closes #162 

This is a first shot at trying to fix some mepo/git weirdness. This update uses `git rev-list` to try and see if two tags are the same. This can then be used in `status` and `compare` so that just in case `mepo` is seeing different tags, we can check if they point to the same commit. If they do, then we just "re-use" the original tag that `mepo clone` used.