### PR TITLE
Add tag push command. Remove --tags from push

### DIFF
--- a/mepo.d/cmdline/parser.py
+++ b/mepo.d/cmdline/parser.py
@@ -283,12 +283,8 @@ class MepoArgParser(object):
     def __push(self):
         push = self.subparsers.add_parser(
             'push',
-            description = 'Push local commits or tags to remote for specified component',
+            description = 'Push local commits to remote for specified component. Use mepo tag push to push tags',
             aliases=mepoconfig.get_command_alias('push'))
-        push.add_argument(
-            '--tags',
-            action = 'store_true',
-            help = 'push tags')
         push.add_argument(
             'comp_name',
             metavar = 'comp-name',
@@ -298,12 +294,8 @@ class MepoArgParser(object):
     def __push_all(self):
         push_all = self.subparsers.add_parser(
             'push-all',
-            description = 'Push local commits or tags to remote for all components',
+            description = 'Push local commits remote for all components. Use mepo tag push to push tags',
             aliases=mepoconfig.get_command_alias('push-all'))
-        push_all.add_argument(
-            '--tags',
-            action = 'store_true',
-            help = 'push tags')
 
     def __save(self):
         save = self.subparsers.add_parser(

--- a/mepo.d/cmdline/tag_parser.py
+++ b/mepo.d/cmdline/tag_parser.py
@@ -10,6 +10,7 @@ class MepoTagArgParser(object):
         self.__list()
         self.__create()
         self.__delete()
+        self.__push()
 
     def __list(self):
         tglist = self.tag.add_parser(
@@ -54,3 +55,18 @@ class MepoTagArgParser(object):
             metavar = 'comp-name',
             nargs = '*',
             help = 'Component to delete tags in')
+
+    def __push(self):
+        push = self.tag.add_parser(
+            'push',
+            description = 'Push tag <tag-name> in component <comp-name>. If no component is specified, runs over all components')
+        push.add_argument('tag_name', metavar = 'tag-name')
+        push.add_argument(
+            '-f', '--force',
+            action = 'store_true',
+            help = "Force push (be careful!)")
+        push.add_argument(
+            'comp_name',
+            metavar = 'comp-name',
+            nargs = '*',
+            help = 'Component to push tags in')

--- a/mepo.d/command/push-all/push-all.py
+++ b/mepo.d/command/push-all/push-all.py
@@ -7,6 +7,6 @@ def run(args):
     allcomps = MepoState.read_state()
     for comp in allcomps:
         git = GitRepository(comp.remote, comp.local)
-        output = git.push(args.tags)
+        output = git.push()
         print('----------\nPushed: {}\n----------'.format(comp.name))
         print(output)

--- a/mepo.d/command/push/push.py
+++ b/mepo.d/command/push/push.py
@@ -8,6 +8,6 @@ def run(args):
     comps2push = [x for x in allcomps if x.name in args.comp_name]
     for comp in comps2push:
         git = GitRepository(comp.remote, comp.local)
-        output = git.push(args.tags)
+        output = git.push()
         print('----------\nPushed: {}\n----------'.format(comp.name))
         print(output)

--- a/mepo.d/command/tag/push/push.py
+++ b/mepo.d/command/tag/push/push.py
@@ -1,0 +1,19 @@
+from state.state import MepoState
+from utilities import verify
+from repository.git import GitRepository
+
+def run(args):
+    allcomps = MepoState.read_state()
+    verify.valid_components(args.comp_name, allcomps)
+    comps2tagpush = _get_comps_to_list(args.comp_name, allcomps)
+    for comp in comps2tagpush:
+        git = GitRepository(comp.remote, comp.local)
+        git.push_tag(args.tag_name,args.force)
+        print(f'Pushed tag {args.tag_name} to {comp.name}')
+
+def _get_comps_to_list(specified_comps, allcomps):
+    comps_to_list = allcomps
+    if specified_comps:
+        verify.valid_components(specified_comps, allcomps)
+        comps_to_list = [x for x in allcomps if x.name in specified_comps]
+    return comps_to_list

--- a/mepo.d/command/tag/tag.py
+++ b/mepo.d/command/tag/tag.py
@@ -5,11 +5,13 @@ from state.state import MepoState
 from command.tag.tglist import tglist
 from command.tag.create import create
 from command.tag.delete import delete
+from command.tag.push import push
 
 def run(args):
     d = {
         'list': tglist,
         'create': create,
-        'delete': delete
+        'delete': delete,
+        'push': push
     }
     d[args.mepo_tag_cmd].run(args)

--- a/mepo.d/repository/git.py
+++ b/mepo.d/repository/git.py
@@ -144,6 +144,13 @@ class GitRepository(object):
         cmd = self.__git + ' tag -d {}'.format(tag_name)
         shellcmd.run(cmd.split())
 
+    def push_tag(self, tag_name, force):
+        cmd = self.__git + ' push'
+        if force:
+            cmd += ' --force'
+        cmd += ' origin {}'.format(tag_name)
+        shellcmd.run(cmd.split())
+
     def verify_branch(self, branch_name):
         cmd = self.__git + ' show-branch remotes/origin/{}'.format(branch_name)
         status = shellcmd.run(cmd.split(),status=True)
@@ -261,11 +268,8 @@ class GitRepository(object):
             raise Exception("This should not happen")
         shellcmd.run(cmd)
 
-    def push(self,tags):
-        if tags:
-            cmd = self.__git + ' push --tags {}'.format(self.__remote)
-        else:
-            cmd = self.__git + ' push -u {}'.format(self.__remote)
+    def push(self):
+        cmd = self.__git + ' push -u {}'.format(self.__remote)
         return shellcmd.run(cmd.split(), output=True).strip()
 
     def get_remote_latest_commit_id(self, branch, commit_type):

--- a/mepo.d/utest/input/components.yaml
+++ b/mepo.d/utest/input/components.yaml
@@ -5,13 +5,13 @@ GEOSfvdycore:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v3.2.0
+  tag: v3.2.1
   develop: main
 
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.3.9
+  tag: v3.4.2
   develop: develop
 
 ecbuild:
@@ -22,26 +22,26 @@ ecbuild:
 GMAO_Shared:
   local: ./src/Shared/@GMAO_Shared
   remote: ../GMAO_Shared.git
-  tag: v1.3.10
+  tag: v1.4.1
   sparse: ./config/GMAO_Shared.sparse
   develop: main
 
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.6.4
+  tag: v2.7.0
   develop: develop
 
 FMS:
   local: ./src/Shared/@FMS
   remote: ../FMS.git
-  tag: geos/2019.01.02+noaff.6
+  tag: geos/2019.01.02+noaff.7
   develop: geos/release/2019.01
 
 FVdycoreCubed_GridComp:
   local: ./src/Components/@FVdycoreCubed_GridComp
   remote: ../FVdycoreCubed_GridComp.git
-  tag: v1.2.12
+  tag: v1.2.15
   develop: develop
 
 fvdycore:

--- a/mepo.d/utest/output/compare_no_change.txt
+++ b/mepo.d/utest/output/compare_no_change.txt
@@ -1,11 +1,11 @@
 Repo                   | Original                         | Current
 ---------------------- | -------------------------------- | -------
-GEOSfvdycore           | (b) main                         | (b) main
-env                    | (t) v3.2.0 (DH)                  | (t) v3.2.0 (DH)
-cmake                  | (t) v3.3.9 (DH)                  | (t) v3.3.9 (DH)
+GEOSfvdycore           | (t) v1.2.7 (DH)                  | (t) v1.2.7 (DH)
+env                    | (t) v3.2.1 (DH)                  | (t) v3.2.1 (DH)
+cmake                  | (t) v3.4.2 (DH)                  | (t) v3.4.2 (DH)
 ecbuild                | (t) geos/v1.0.6 (DH)             | (t) geos/v1.0.6 (DH)
-GMAO_Shared            | (t) v1.3.10 (DH)                 | (t) v1.3.10 (DH)
-MAPL                   | (t) v2.6.4 (DH)                  | (t) v2.6.4 (DH)
-FMS                    | (t) geos/2019.01.02+noaff.6 (DH) | (t) geos/2019.01.02+noaff.6 (DH)
-FVdycoreCubed_GridComp | (t) v1.2.12 (DH)                 | (t) v1.2.12 (DH)
+GMAO_Shared            | (t) v1.4.1 (DH)                  | (t) v1.4.1 (DH)
+MAPL                   | (t) v2.7.0 (DH)                  | (t) v2.7.0 (DH)
+FMS                    | (t) geos/2019.01.02+noaff.7 (DH) | (t) geos/2019.01.02+noaff.7 (DH)
+FVdycoreCubed_GridComp | (t) v1.2.15 (DH)                 | (t) v1.2.15 (DH)
 fvdycore               | (t) geos/v1.1.6 (DH)             | (t) geos/v1.1.6 (DH)

--- a/mepo.d/utest/output/status_output.txt
+++ b/mepo.d/utest/output/status_output.txt
@@ -1,10 +1,10 @@
 Checking status...
-GEOSfvdycore           | (b) main
-env                    | (t) v3.2.0 (DH)
-cmake                  | (t) v3.3.9 (DH)
+GEOSfvdycore           | (t) v1.2.7 (DH)
+env                    | (t) v3.2.1 (DH)
+cmake                  | (t) v3.4.2 (DH)
 ecbuild                | (t) geos/v1.0.6 (DH)
-GMAO_Shared            | (t) v1.3.10 (DH)
-MAPL                   | (t) v2.6.4 (DH)
-FMS                    | (t) geos/2019.01.02+noaff.6 (DH)
-FVdycoreCubed_GridComp | (t) v1.2.12 (DH)
+GMAO_Shared            | (t) v1.4.1 (DH)
+MAPL                   | (t) v2.7.0 (DH)
+FMS                    | (t) geos/2019.01.02+noaff.7 (DH)
+FVdycoreCubed_GridComp | (t) v1.2.15 (DH)
 fvdycore               | (t) geos/v1.1.6 (DH)

--- a/mepo.d/utest/test_mepo_commands.py
+++ b/mepo.d/utest/test_mepo_commands.py
@@ -19,7 +19,7 @@ class TestMepoCommands(unittest.TestCase):
     @classmethod
     def __checkout_fixture(cls):
         remote = 'https://github.com/GEOS-ESM/{}.git'.format(cls.fixture)
-        cmd = 'git clone {} {}'.format(remote, cls.fixture_dir)
+        cmd = 'git clone -b {} {} {}'.format(cls.tag, remote, cls.fixture_dir)
         sp.run(cmd.split())
 
     @classmethod
@@ -33,6 +33,7 @@ class TestMepoCommands(unittest.TestCase):
         cls.input_dir = os.path.join(THIS_DIR, 'input')
         cls.output_dir = os.path.join(THIS_DIR, 'output')
         cls.fixture = 'GEOSfvdycore'
+        cls.tag = 'v1.2.7'
         cls.tmpdir = os.path.join(THIS_DIR, 'tmp')
         cls.fixture_dir = os.path.join(cls.tmpdir, cls.fixture)
         if os.path.isdir(cls.fixture_dir):


### PR DESCRIPTION
This PR is needed to allow force pushing tags. While we don't want this it is needed for some scenarios. But, at least with this PR, you can only force push a single tag. Before when it used `git push --tags` there was a chance to screw things up as that pushes *all* tags.

Now you have to run `mepo tag push TAG [REPO]` to push a tag. Also added a `--force` flag because scary as it is, it is needed at times (otherwise people have to do scary git commands).