### PR TITLE
Fix default style if none specified

### DIFF
--- a/mepo.d/command/init/init.py
+++ b/mepo.d/command/init/init.py
@@ -12,8 +12,11 @@ def run(args):
         else:
             print(f'Found style [{style}] in .mepoconfig')
     else:
-        style = 'prefix'
+        style = None
 
     allcomps = MepoState.initialize(args.config,style)
 
-    print(f'Initializing mepo using {args.config} with {style} style.')
+    if not style:
+        print(f'Initializing mepo using {args.config}')
+    else:
+        print(f'Initializing mepo using {args.config} with {style} style')

--- a/mepo.d/state/component.py
+++ b/mepo.d/state/component.py
@@ -170,14 +170,20 @@ def get_current_remote_url():
     return output
 
 def decorate_node(item, flag, style):
-    item = item.replace(flag,'')
-    if style == 'naked':
-        output = item
-    elif style == 'prefix':
-        output = flag + item
-    elif style == 'postfix':
-        output = item + flag
-    return output
+    # If we do not pass in a style...
+    if not style:
+        # Just use what's in components.yaml
+        return item
+    # else use the style
+    else:
+        item = item.replace(flag,'')
+        if style == 'naked':
+            output = item
+        elif style == 'prefix':
+            output = flag + item
+        elif style == 'postfix':
+            output = item + flag
+        return output
 
 # From https://learning.oreilly.com/library/view/python-cookbook/0596001673/ch04s16.html
 def splitall(path):


### PR DESCRIPTION
Until GEOS-ESM fixtures can be fixed up to support all styles, to make things easy, if no style is specified on command line or in `.mepoconfig`, just use what `components.yaml` says to do. 