### PR TITLE
Add allrepos option to clone

### DIFF
--- a/mepo.d/cmdline/parser.py
+++ b/mepo.d/cmdline/parser.py
@@ -100,6 +100,10 @@ class MepoArgParser(object):
             default = None,
             choices = ['naked', 'prefix','postfix'],
             help = 'Style of directory file, default: prefix, allowed options: %(choices)s (ignored if init already called)')
+        clone.add_argument(
+            '--allrepos',
+            action = 'store_true',
+            help = 'Must be passed with -b/--branch. When set, it not only checkouts out the branch/tag for the fixture, but for all the subrepositories as well.')
 
     def __list(self):
         listcomps = self.subparsers.add_parser(

--- a/mepo.d/command/clone/clone.py
+++ b/mepo.d/command/clone/clone.py
@@ -1,7 +1,7 @@
 from state.state    import MepoState, StateDoesNotExistError
 from repository.git import GitRepository
 from command.init   import init as mepo_init
-from utilities      import shellcmd
+from utilities      import shellcmd, colors
 from urllib.parse   import urlparse
 
 import os
@@ -13,6 +13,9 @@ def run(args):
     # This protects against someone using branch without a URL
     if args.branch and not args.repo_url:
         raise RuntimeError("The branch argument can only be used with a URL")
+
+    if args.allrepos and not args.branch:
+        raise RuntimeError("The allrepos option must be used with a branch/tag.")
 
     # If you pass in a config, with clone, it could be outside the repo.
     # So use the full path
@@ -70,6 +73,15 @@ def run(args):
                 git.sparsify(comp.sparse)
             #git.checkout(comp.version.name)
             print_clone_info(comp, max_namelen)
+
+    if args.allrepos:
+        for comp in allcomps:
+            if not comp.fixture:
+                git = GitRepository(comp.remote, comp.local)
+                print("Checking out %s in %s" %
+                        (colors.YELLOW + args.branch + colors.RESET,
+                        colors.RESET + comp.name + colors.RESET))
+                git.checkout(args.branch)
 
 def print_clone_info(comp, name_width):
     ver_name_type = '({}) {}'.format(comp.version.type, comp.version.name)

--- a/mepo.d/utest/input/args.py
+++ b/mepo.d/utest/input/args.py
@@ -1,1 +1,2 @@
 config_file = None
+allrepos = None


### PR DESCRIPTION
Based on a workflow suggested by @rtodling, this PR adds a new `--allrepos` option to `mepo clone`. With this flag, not only is the tag/branch passed to the `--branch/-b` option to `mepo clone` checked out, but it also checks out that tag in *all sub repositories*!

To wit, if you do:
```
mepo clone -b <tag> --allrepos fixture-repo
```
what this will do is:
```
git clone -b fixture-repo
cd fixture-repo
mepo clone
mepo checkout <tag> [on all subrepos]
```

Note this means it will fail if the tag requested is not on all repos! 