### PR TITLE
Allow checkout on all repos

### DIFF
--- a/mepo.d/cmdline/parser.py
+++ b/mepo.d/cmdline/parser.py
@@ -143,9 +143,10 @@ class MepoArgParser(object):
     def __checkout(self):
         checkout = self.subparsers.add_parser(
             'checkout',
-            description = 'Switch to branch `branch-name` in component `comp-name`. '
-            'Specifying `-b` causes the branch `branch-name` to be created in '
-            'the specified component(s).',
+            description = "Switch to branch/tag `branch-name` in component `comp-name`. "
+            "If no components listed, checkout from all. "
+            "Specifying `-b` causes the branch `branch-name` to be created in "
+            "the specified component(s). NOTE: the -b option *requires* components to be specified.",
             aliases=mepoconfig.get_command_alias('checkout'))
         checkout.add_argument(
             'branch_name',
@@ -154,7 +155,7 @@ class MepoArgParser(object):
         checkout.add_argument(
             'comp_name',
             metavar = 'comp-name',
-            nargs = '+',
+            nargs = '*',
             help = 'Components to checkout branch in')
         checkout.add_argument(
             '-b',

--- a/mepo.d/command/checkout/checkout.py
+++ b/mepo.d/command/checkout/checkout.py
@@ -5,8 +5,9 @@ from utilities import colors
 
 def run(args):
     allcomps = MepoState.read_state()
-    verify.valid_components(args.comp_name, allcomps)
-    comps2checkout = [x for x in allcomps if x.name in args.comp_name]
+    comps2checkout = _get_comps_to_list(args.comp_name, allcomps)
+    if args.b and comps2checkout == allcomps:
+        raise Exception("We do not allow creating branches without specifying specific repos")
     for comp in comps2checkout:
         git = GitRepository(comp.remote, comp.local)
         branch = args.branch_name
@@ -23,3 +24,11 @@ def run(args):
                         (colors.YELLOW + branch + colors.RESET,
                         colors.RESET + comp.name + colors.RESET))
         git.checkout(branch)
+
+def _get_comps_to_list(specified_comps, allcomps):
+    comps_to_list = allcomps
+    if specified_comps:
+        verify.valid_components(specified_comps, allcomps)
+        comps_to_list = [x for x in allcomps if x.name in specified_comps]
+    return comps_to_list
+


### PR DESCRIPTION
In doing some experimenting, it was found that the `checkout` command sort of doesn't fit in the "allow a (safe) command to run on all repos" style of mepo (see how `fetch` was extended).

So, what this PR does is allow for `mepo checkout foo` to run on *all repos* if no component is specified. 

BUUUUUUUT, we *DO NOT ALLOW* `mepo checkout -b newbranch`. If you want to create and make a new branch, you need to do it specifically on repos. You should *think* about that one!