### PR TITLE
Fix save and allow hash in components.yaml

### DIFF
--- a/mepo.d/command/clone/clone.py
+++ b/mepo.d/command/clone/clone.py
@@ -68,10 +68,11 @@ def run(args):
             version = comp.version.name
             version = version.replace('origin/','')
             recurse = comp.recurse_submodules
-            git.clone(version,recurse)
+            # We need the type to handle hashes in components.yaml
+            type = comp.version.type
+            git.clone(version,recurse,type)
             if comp.sparse:
                 git.sparsify(comp.sparse)
-            #git.checkout(comp.version.name)
             print_clone_info(comp, max_namelen)
 
     if args.allrepos:

--- a/mepo.d/repository/git.py
+++ b/mepo.d/repository/git.py
@@ -37,12 +37,19 @@ class GitRepository(object):
     def get_remote_url(self):
         return self.__remote
 
-    def clone(self, version, recurse):
+    def clone(self, version, recurse, type):
         cmd = 'git clone '
         if recurse:
             cmd += '--recurse-submodules '
-        cmd += '--branch {} --quiet {} {}'.format(version, self.__remote, self.__local)
-        shellcmd.run(cmd.split())
+        # You can't git clone -b hash, so we need to do different things
+        if type == 'h':
+            cmd += '--quiet {} {}'.format(self.__remote, self.__local)
+            shellcmd.run(cmd.split())
+            cmd2 = 'git -C {} checkout {}'.format(self.__local, version)
+            shellcmd.run(cmd2.split())
+        else:
+            cmd += '--branch {} --quiet {} {}'.format(version, self.__remote, self.__local)
+            shellcmd.run(cmd.split())
 
     def checkout(self, version):
         cmd = self.__git + ' checkout --quiet {}'.format(version)

--- a/mepo.d/state/component.py
+++ b/mepo.d/state/component.py
@@ -10,21 +10,21 @@ original_final_node_list = []
 
 class MepoComponent(object):
 
-    __slots__ = ['name', 'local', 'remote', 'version', 'develop', 'sparse', 'recurse_submodules', 'fixture']
+    __slots__ = ['name', 'local', 'remote', 'version', 'sparse', 'develop', 'recurse_submodules', 'fixture']
 
     def __init__(self):
         self.name = None
         self.local = None
         self.remote = None
         self.version = None
-        self.develop = None
         self.sparse = None
+        self.develop = None
         self.recurse_submodules = None
         self.fixture = None
 
     def __repr__(self):
-        return '{} - local: {}, remote: {}, version: {}, develop: {}, sparse: {}, recurse_submodules: {}, fixture: {}'.format(
-            self.name, self.local, self.remote, self.version, self.develop, self.sparse, self.recurse_submodules, self.fixture)
+        return '{} - local: {}, remote: {}, version: {}, sparse: {}, develop: {}, recurse_submodules: {}, fixture: {}'.format(
+            self.name, self.local, self.remote, self.version, self.sparse, self.develop, self.recurse_submodules, self.fixture)
 
     def __set_original_version(self, comp_details):
         if self.fixture:
@@ -75,7 +75,7 @@ class MepoComponent(object):
             raise Exception("Fixtures are only allowed fixture and develop")
 
     def __validate_component(self, comp_name, comp_details):
-        types_of_git_tags = ['branch', 'tag']
+        types_of_git_tags = ['branch', 'tag', 'hash']
         git_tag_intersection = set(types_of_git_tags).intersection(set(comp_details.keys()))
         if len(git_tag_intersection) == 0:
             raise Exception(textwrap.fill(textwrap.dedent(f'''
@@ -131,8 +131,8 @@ class MepoComponent(object):
             #print(f'final self.local: {self.local}')
 
             self.remote = comp_details['remote']
-        self.develop = comp_details.get('develop', None) # develop is optional
         self.sparse = comp_details.get('sparse', None) # sparse is optional
+        self.develop = comp_details.get('develop', None) # develop is optional
         self.recurse_submodules = comp_details.get('recurse_submodules', None) # recurse_submodules is optional
         self.__set_original_version(comp_details)
         return self
@@ -156,10 +156,10 @@ class MepoComponent(object):
                     details['branch'] = self.version.name.replace('origin/', '')
                 else:
                     details['branch'] = self.version.name
-            if self.develop:
-                details['develop'] = self.develop
             if self.sparse:
                 details['sparse'] = self.sparse
+            if self.develop:
+                details['develop'] = self.develop
             if self.recurse_submodules:
                 details['recurse_submodules'] = self.recurse_submodules
         return {self.name: details}


### PR DESCRIPTION
Recent developments in the GEOS repos in re tags broke `mepo save`. As this might be needed functionality soon (see #180), we need to fix it.

Also, in this PR, we allow `components.yaml` to use something like:
```yaml
ESMA_cmake:
  local: ./ESMA_cmake
  remote: ../ESMA_cmake.git
  hash: a64765f4ddc00c62b441bb08b31585cfa645756e
  develop: develop
```

This needs changes because `git clone -b hash` is not allowed. Only tags and branches (I think?) are allowed:

       -b <name>, --branch <name>
           Instead of pointing the newly created HEAD to the branch pointed to by the cloned repository's HEAD, point to <name> branch instead. In a non-bare repository,
           this is the branch that will be checked out.  --branch can also take tags and detaches the HEAD at that commit in the resulting repository.

These updates also triggered cascades into fixing `mepo status` and `mepo compare` as we touched the sanitizer code.