### PR TITLE
Make pull commands noisy by default

### DIFF
--- a/mepo.d/cmdline/parser.py
+++ b/mepo.d/cmdline/parser.py
@@ -259,12 +259,20 @@ class MepoArgParser(object):
             nargs = '+',
             default = None,
             help = "Components to pull in")
+        pull.add_argument(
+            '-q','--quiet',
+            action = 'store_true',
+            help = 'Suppress prints')
 
     def __pull_all(self):
         pull_all = self.subparsers.add_parser(
             'pull-all',
             description = "Pull branches of all components (only those in non-detached HEAD state)",
             aliases=mepoconfig.get_command_alias('pull-all'))
+        pull_all.add_argument(
+            '-q','--quiet',
+            action = 'store_true',
+            help = 'Suppress prints')
 
     def __compare(self):
         compare = self.subparsers.add_parser(

--- a/mepo.d/command/develop/develop.py
+++ b/mepo.d/command/develop/develop.py
@@ -16,4 +16,4 @@ def run(args):
                     (colors.YELLOW + comp.develop + colors.RESET,
                     colors.RESET + comp.name + colors.RESET))
         git.checkout(comp.develop)
-        git.pull()
+        output = git.pull()

--- a/mepo.d/command/pull-all/pull-all.py
+++ b/mepo.d/command/pull-all/pull-all.py
@@ -15,7 +15,8 @@ def run(args):
             print("Pulling branch %s in %s " %
                     (colors.YELLOW + name + colors.RESET,
                      colors.RESET + comp.name + colors.RESET))
-            git.pull()
+            output = git.pull()
+            if not args.quiet: print(output)
     if len(detached_comps) > 0:
         print("The following repos were not pulled (detached HEAD): %s" % (', '.join(map(str, detached_comps))))
 

--- a/mepo.d/command/pull/pull.py
+++ b/mepo.d/command/pull/pull.py
@@ -17,4 +17,5 @@ def run(args):
             print("Pulling branch %s in %s " %
                     (colors.YELLOW + name + colors.RESET,
                      colors.RESET + comp.name + colors.RESET))
-            git.pull()
+            output = git.pull()
+            if not args.quiet: print(output)

--- a/mepo.d/repository/git.py
+++ b/mepo.d/repository/git.py
@@ -312,7 +312,7 @@ class GitRepository(object):
 
     def pull(self):
         cmd = self.__git + ' pull'
-        shellcmd.run(cmd.split())
+        return shellcmd.run(cmd.split(), output=True).strip()
 
     def get_version(self):
         cmd = self.__git + ' show -s --pretty=%D HEAD'


### PR DESCRIPTION
The `mepo pull` command was a bit too quiet by default. You never knew if anything happened. Now it's noisy by default and can be quieted with `--quiet`