### PR TITLE
Fixes for handling paths with spaces

### DIFF
--- a/mepo.d/command/clone/clone.py
+++ b/mepo.d/command/clone/clone.py
@@ -7,6 +7,7 @@ from urllib.parse   import urlparse
 import os
 import pathlib
 import shutil
+import shlex
 
 def run(args):
 
@@ -94,5 +95,5 @@ def local_clone(url,branch=None,directory=None):
         cmd += '--branch {} '.format(branch)
     cmd += '--quiet {}'.format(url)
     if directory:
-        cmd += ' {}'.format(directory)
-    shellcmd.run(cmd.split())
+        cmd += ' "{}"'.format(directory)
+    shellcmd.run(shlex.split(cmd))

--- a/mepo.d/repository/git.py
+++ b/mepo.d/repository/git.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import subprocess
+import shlex
 
 from state.state import MepoState
 from utilities import shellcmd
@@ -26,7 +27,7 @@ class GitRepository(object):
         root_dir = MepoState.get_root_dir()
         full_local_path=os.path.join(root_dir,local_path)
         self.__full_local_path=full_local_path
-        self.__git = 'git -C {}'.format(self.__full_local_path)
+        self.__git = 'git -C "{}"'.format(self.__full_local_path)
 
     def get_local_path(self):
         return self.__local
@@ -44,63 +45,63 @@ class GitRepository(object):
         # You can't git clone -b hash, so we need to do different things
         if type == 'h':
             cmd += '--quiet {} {}'.format(self.__remote, self.__local)
-            shellcmd.run(cmd.split())
+            shellcmd.run(shlex.split(cmd))
             cmd2 = 'git -C {} checkout {}'.format(self.__local, version)
-            shellcmd.run(cmd2.split())
+            shellcmd.run(shlex.split(cmd2))
         else:
             cmd += '--branch {} --quiet {} {}'.format(version, self.__remote, self.__local)
-            shellcmd.run(cmd.split())
+            shellcmd.run(shlex.split(cmd))
 
     def checkout(self, version):
         cmd = self.__git + ' checkout --quiet {}'.format(version)
-        shellcmd.run(cmd.split())
+        shellcmd.run(shlex.split(cmd))
 
     def sparsify(self, sparse_config):
         dst = os.path.join(self.__local, '.git', 'info', 'sparse-checkout')
         os.makedirs(os.path.dirname(dst), exist_ok=True)
         shutil.copy(sparse_config, dst)
         cmd1 = self.__git + ' config core.sparseCheckout true'
-        shellcmd.run(cmd1.split())
+        shellcmd.run(shlex.split(cmd1))
         cmd2 = self.__git + ' read-tree -mu HEAD'
-        shellcmd.run(cmd2.split())
+        shellcmd.run(shlex.split(cmd2))
 
     def list_branch(self, all=False):
         cmd = self.__git + ' branch'
         if all:
             cmd += ' -a'
-        return shellcmd.run(cmd.split(), output=True)
+        return shellcmd.run(shlex.split(cmd), output=True)
 
     def list_tags(self):
         cmd = self.__git + ' tag'
-        return shellcmd.run(cmd.split(), output=True)
+        return shellcmd.run(shlex.split(cmd), output=True)
 
     def rev_list(self, tag):
         cmd = self.__git + ' rev-list -n 1 {}'.format(tag)
-        return shellcmd.run(cmd.split(), output=True)
+        return shellcmd.run(shlex.split(cmd), output=True)
 
     def list_stash(self):
         cmd = self.__git + ' stash list'
-        return shellcmd.run(cmd.split(), output=True)
+        return shellcmd.run(shlex.split(cmd), output=True)
 
     def pop_stash(self):
         cmd = self.__git + ' stash pop'
-        return shellcmd.run(cmd.split(), output=True)
+        return shellcmd.run(shlex.split(cmd), output=True)
 
     def apply_stash(self):
         cmd = self.__git + ' stash apply'
-        return shellcmd.run(cmd.split(), output=True)
+        return shellcmd.run(shlex.split(cmd), output=True)
 
     def push_stash(self, message):
         cmd = self.__git + ' stash push'
         if message:
             cmd += ' -m {}'.format(message)
-        return shellcmd.run(cmd.split(), output=True)
+        return shellcmd.run(shlex.split(cmd), output=True)
 
     def show_stash(self, patch):
         cmd = self.__git + ' stash show'
         if patch:
             cmd += ' -p --color'
-        output = shellcmd.run(cmd.split(),output=True)
+        output = shellcmd.run(shlex.split(cmd),output=True)
         return output.rstrip()
 
     def run_diff(self, args=None):
@@ -109,7 +110,7 @@ class GitRepository(object):
             cmd += ' --name-only'
         if args.staged:
             cmd += ' --staged'
-        output = shellcmd.run(cmd.split(),output=True)
+        output = shellcmd.run(shlex.split(cmd),output=True)
         return output.rstrip()
 
     def fetch(self, args=None):
@@ -122,11 +123,11 @@ class GitRepository(object):
             cmd += ' --tags'
         if args.force:
             cmd += ' --force'
-        return shellcmd.run(cmd.split(), output=True)
+        return shellcmd.run(shlex.split(cmd), output=True)
 
     def create_branch(self, branch_name):
         cmd = self.__git + ' branch {}'.format(branch_name)
-        shellcmd.run(cmd.split())
+        shellcmd.run(shlex.split(cmd))
 
     def create_tag(self, tag_name, annotate, message, tf_file=None):
         if annotate:
@@ -145,27 +146,27 @@ class GitRepository(object):
         if force:
             delete = '-D'
         cmd = self.__git + ' branch {} {}'.format(delete, branch_name)
-        shellcmd.run(cmd.split())
+        shellcmd.run(shlex.split(cmd))
 
     def delete_tag(self, tag_name):
         cmd = self.__git + ' tag -d {}'.format(tag_name)
-        shellcmd.run(cmd.split())
+        shellcmd.run(shlex.split(cmd))
 
     def push_tag(self, tag_name, force):
         cmd = self.__git + ' push'
         if force:
             cmd += ' --force'
         cmd += ' origin {}'.format(tag_name)
-        shellcmd.run(cmd.split())
+        shellcmd.run(shlex.split(cmd))
 
     def verify_branch(self, branch_name):
         cmd = self.__git + ' show-branch remotes/origin/{}'.format(branch_name)
-        status = shellcmd.run(cmd.split(),status=True)
+        status = shellcmd.run(shlex.split(cmd),status=True)
         return status
 
     def check_status(self):
         cmd = self.__git + ' status --porcelain=v2'
-        output = shellcmd.run(cmd.split(), output=True)
+        output = shellcmd.run(shlex.split(cmd), output=True)
         if output.strip():
             output_list = output.splitlines()
 
@@ -239,12 +240,12 @@ class GitRepository(object):
 
     def __get_modified_files(self):
         cmd = self.__git + ' diff --name-only'
-        output = shellcmd.run(cmd.split(), output=True).strip()
+        output = shellcmd.run(shlex.split(cmd), output=True).strip()
         return output.split('\n') if output else []
 
     def __get_untracked_files(self):
         cmd = self.__git + ' ls-files --others --exclude-standard'
-        output = shellcmd.run(cmd.split(), output=True).strip()
+        output = shellcmd.run(shlex.split(cmd), output=True).strip()
         return output.split('\n') if output else []
 
     def get_changed_files(self, untracked=False):
@@ -255,16 +256,16 @@ class GitRepository(object):
 
     def stage_file(self, myfile):
         cmd = self.__git + ' add {}'.format(myfile)
-        shellcmd.run(cmd.split())
+        shellcmd.run(shlex.split(cmd))
 
     def get_staged_files(self):
         cmd = self.__git + ' diff --name-only --staged'
-        output = shellcmd.run(cmd.split(), output=True).strip()
+        output = shellcmd.run(shlex.split(cmd), output=True).strip()
         return output.split('\n') if output else []
 
     def unstage_file(self, myfile):
         cmd = self.__git + ' reset -- {}'.format(myfile)
-        shellcmd.run(cmd.split())
+        shellcmd.run(shlex.split(cmd))
 
     def commit_files(self, message, tf_file=None):
         if tf_file:
@@ -277,12 +278,12 @@ class GitRepository(object):
 
     def push(self):
         cmd = self.__git + ' push -u {}'.format(self.__remote)
-        return shellcmd.run(cmd.split(), output=True).strip()
+        return shellcmd.run(shlex.split(cmd), output=True).strip()
 
     def get_remote_latest_commit_id(self, branch, commit_type):
         if commit_type == 'h':
             cmd = self.__git + ' cat-file -e {}'.format(branch)
-            status = shellcmd.run(cmd.split(), status=True)
+            status = shellcmd.run(shlex.split(cmd), status=True)
             if status != 0:
                 msg = 'Hash {} does not exist on {}'.format(branch, self.__remote)
                 msg += " Have you run 'mepo push'?"
@@ -299,7 +300,7 @@ class GitRepository(object):
             else:
                 raise RuntimeError("Should not get here")
             cmd = self.__git + ' ls-remote {} refs/{}/{}'.format(self.__remote, reftype, branch)
-            output = shellcmd.run(cmd.split(), output=True).strip()
+            output = shellcmd.run(shlex.split(cmd), output=True).strip()
             if not output:
                 msg = '{} {} does not exist on {}'.format(msgtype, branch, self.__remote)
                 msg += " Have you run 'mepo push'?"
@@ -308,15 +309,15 @@ class GitRepository(object):
 
     def get_local_latest_commit_id(self):
         cmd = self.__git + ' rev-parse HEAD'
-        return shellcmd.run(cmd.split(), output=True).strip()
+        return shellcmd.run(shlex.split(cmd), output=True).strip()
 
     def pull(self):
         cmd = self.__git + ' pull'
-        return shellcmd.run(cmd.split(), output=True).strip()
+        return shellcmd.run(shlex.split(cmd), output=True).strip()
 
     def get_version(self):
         cmd = self.__git + ' show -s --pretty=%D HEAD'
-        output = shellcmd.run(cmd.split(), output=True)
+        output = shellcmd.run(shlex.split(cmd), output=True)
         if output.startswith('HEAD ->'): # an actual branch
             detached = False
             name = output.split(',')[0].split('->')[1].strip()
@@ -334,13 +335,13 @@ class GitRepository(object):
                 tYpe = 'b'
         elif output.startswith('HEAD'): # Assume hash
             cmd = self.__git + ' rev-parse HEAD'
-            hash_out = shellcmd.run(cmd.split(), output=True)
+            hash_out = shellcmd.run(shlex.split(cmd), output=True)
             detached = True
             name = hash_out.rstrip()
             tYpe = 'h'
         elif output.startswith('grafted'):
             cmd = self.__git + ' describe --always'
-            hash_out = shellcmd.run(cmd.split(), output=True)
+            hash_out = shellcmd.run(shlex.split(cmd), output=True)
             detached = True
             name = hash_out.rstrip()
             tYpe = 'h'
@@ -348,5 +349,5 @@ class GitRepository(object):
 
 def get_current_remote_url():
     cmd = 'git remote get-url origin'
-    output = shellcmd.run(cmd.split(), output=True).strip()
+    output = shellcmd.run(shlex.split(cmd), output=True).strip()
     return output

--- a/mepo.d/state/component.py
+++ b/mepo.d/state/component.py
@@ -1,4 +1,5 @@
 import os
+import shlex
 import textwrap
 from collections import namedtuple
 from utilities.version import MepoVersion
@@ -166,7 +167,7 @@ class MepoComponent(object):
 
 def get_current_remote_url():
     cmd = 'git remote get-url origin'
-    output = shellcmd.run(cmd.split(), output=True).strip()
+    output = shellcmd.run(shlex.split(cmd), output=True).strip()
     return output
 
 def decorate_node(item, flag, style):

--- a/mepo.d/utest/test_mepo_commands.py
+++ b/mepo.d/utest/test_mepo_commands.py
@@ -3,6 +3,7 @@ import sys
 THIS_DIR = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, os.path.join(THIS_DIR, '..'))
 import shutil
+import shlex
 import unittest
 import subprocess as sp
 from io import StringIO
@@ -20,7 +21,7 @@ class TestMepoCommands(unittest.TestCase):
     def __checkout_fixture(cls):
         remote = 'https://github.com/GEOS-ESM/{}.git'.format(cls.fixture)
         cmd = 'git clone -b {} {} {}'.format(cls.tag, remote, cls.fixture_dir)
-        sp.run(cmd.split())
+        sp.run(shlex.split(cmd))
 
     @classmethod
     def __copy_config_file(cls):


### PR DESCRIPTION
Closes #190 

The fix mainly involves using `shlex.split` when interacting with `subprocess`. Also quoting paths in a few places so `shlex` can do its thing.

Tested by:
```
mkdir ~/Directory\ With\ Spaces
cd !$
mepo clone -b feature/geos-v10.17.6/gocart2g/v2.0.0 git@github.com:GEOS-ESM/GEOSgcm.git BOBO\ JOJO\ DODO
cd !$
```
and all subcommands seem happy.