### PR TITLE
Allow checkout -b for all repos

### DIFF
--- a/mepo.d/cmdline/parser.py
+++ b/mepo.d/cmdline/parser.py
@@ -145,8 +145,7 @@ class MepoArgParser(object):
             'checkout',
             description = "Switch to branch/tag `branch-name` in component `comp-name`. "
             "If no components listed, checkout from all. "
-            "Specifying `-b` causes the branch `branch-name` to be created in "
-            "the specified component(s). NOTE: the -b option *requires* components to be specified.",
+            "Specifying `-b` causes the branch `branch-name` to be created and checked out.",
             aliases=mepoconfig.get_command_alias('checkout'))
         checkout.add_argument(
             'branch_name',

--- a/mepo.d/command/checkout/checkout.py
+++ b/mepo.d/command/checkout/checkout.py
@@ -5,9 +5,7 @@ from utilities import colors
 
 def run(args):
     allcomps = MepoState.read_state()
-    comps2checkout = _get_comps_to_list(args.comp_name, allcomps)
-    if args.b and comps2checkout == allcomps:
-        raise Exception("We do not allow creating branches without specifying specific repos")
+    comps2checkout = _get_comps_to_checkout(args.comp_name, allcomps)
     for comp in comps2checkout:
         git = GitRepository(comp.remote, comp.local)
         branch = args.branch_name
@@ -25,7 +23,7 @@ def run(args):
                         colors.RESET + comp.name + colors.RESET))
         git.checkout(branch)
 
-def _get_comps_to_list(specified_comps, allcomps):
+def _get_comps_to_checkout(specified_comps, allcomps):
     comps_to_list = allcomps
     if specified_comps:
         verify.valid_components(specified_comps, allcomps)


### PR DESCRIPTION
This allows `checkout -b` to be run on all repos with no repos to `mepo`