### PR TITLE
Detach branches on clone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Removed
+
+## [1.38.0] - 2021-09-10
+
+### Added
+
 - Added `CHANGELOG.md`
 - Added changelog enforcer
 
 ### Changed
 
 - Detach branches on clone
-
-### Removed
 
 ## [1.37.1] - 2021-09-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Detach branches on clone
+
 ### Removed
 
 ## [1.37.1] - 2021-09-02

--- a/mepo.d/cmdline/parser.py
+++ b/mepo.d/cmdline/parser.py
@@ -164,6 +164,10 @@ class MepoArgParser(object):
             '-q', '--quiet',
             action = 'store_true',
             help = 'Suppress prints')
+        checkout.add_argument(
+            '--detach',
+            action = 'store_true',
+            help = 'Detach upon checkout')
 
     def __checkout_if_exists(self):
         checkout_if_exists = self.subparsers.add_parser(
@@ -178,6 +182,10 @@ class MepoArgParser(object):
             '-q', '--quiet',
             action = 'store_true',
             help = 'Suppress prints')
+        checkout_if_exists.add_argument(
+            '--detach',
+            action = 'store_true',
+            help = 'Detach on checkout')
         checkout_if_exists.add_argument(
             '-n','--dry-run',
             action = 'store_true',

--- a/mepo.d/command/checkout-if-exists/checkout-if-exists.py
+++ b/mepo.d/command/checkout-if-exists/checkout-if-exists.py
@@ -20,4 +20,4 @@ def run(args):
                     print("Checking out branch %s in %s" %
                             (colors.YELLOW + branch + colors.RESET,
                             colors.RESET + comp.name + colors.RESET))
-                git.checkout(branch)
+                git.checkout(branch,args.detach)

--- a/mepo.d/command/checkout/checkout.py
+++ b/mepo.d/command/checkout/checkout.py
@@ -21,7 +21,7 @@ def run(args):
                 print("Checking out %s in %s" %
                         (colors.YELLOW + branch + colors.RESET,
                         colors.RESET + comp.name + colors.RESET))
-        git.checkout(branch)
+        git.checkout(branch,args.detach)
 
 def _get_comps_to_checkout(specified_comps, allcomps):
     comps_to_list = allcomps

--- a/mepo.d/command/clone/clone.py
+++ b/mepo.d/command/clone/clone.py
@@ -42,7 +42,7 @@ def run(args):
             else:
                 git_url_directory = last_url_node
 
-            local_clone(args.repo_url,args.branch)
+            local_clone(args.repo_url,args.branch,git_url_directory)
             os.chdir(git_url_directory)
 
     # Copy the new file into the repo only if we pass it in
@@ -83,17 +83,20 @@ def run(args):
                 print("Checking out %s in %s" %
                         (colors.YELLOW + args.branch + colors.RESET,
                         colors.RESET + comp.name + colors.RESET))
-                git.checkout(args.branch)
+                git.checkout(args.branch,detach=True)
 
 def print_clone_info(comp, name_width):
     ver_name_type = '({}) {}'.format(comp.version.type, comp.version.name)
     print('{:<{width}} | {:<s}'.format(comp.name, ver_name_type, width = name_width))
 
 def local_clone(url,branch=None,directory=None):
-    cmd = 'git clone '
+    cmd1 = 'git clone '
     if branch:
-        cmd += '--branch {} '.format(branch)
-    cmd += '--quiet {}'.format(url)
+        cmd1 += '--branch {} '.format(branch)
+    cmd1 += '--quiet {}'.format(url)
     if directory:
-        cmd += ' "{}"'.format(directory)
-    shellcmd.run(shlex.split(cmd))
+        cmd1 += ' "{}"'.format(directory)
+    shellcmd.run(shlex.split(cmd1))
+    if branch:
+        cmd2 = f'git -C {directory} checkout --detach {branch}'
+        shellcmd.run(shlex.split(cmd2))

--- a/mepo.d/repository/git.py
+++ b/mepo.d/repository/git.py
@@ -57,10 +57,11 @@ class GitRepository(object):
 
     def checkout(self, version, detach=False):
         cmd = self.__git + ' checkout '
-        if detach:
-           cmd += '--detach '
         cmd += '--quiet {}'.format(version)
         shellcmd.run(shlex.split(cmd))
+        if detach:
+           cmd2 = self.__git + ' checkout --detach'
+           shellcmd.run(shlex.split(cmd2))
 
     def sparsify(self, sparse_config):
         dst = os.path.join(self.__local, '.git', 'info', 'sparse-checkout')

--- a/mepo.d/repository/git.py
+++ b/mepo.d/repository/git.py
@@ -39,21 +39,20 @@ class GitRepository(object):
         return self.__remote
 
     def clone(self, version, recurse, type):
-        cmd = 'git clone '
+        cmd1 = 'git clone '
         if recurse:
-            cmd += '--recurse-submodules '
-        # You can't git clone -b hash, so we need to do different things
-        if type == 'h':
-            cmd += '--quiet {} {}'.format(self.__remote, self.__local)
-            shellcmd.run(shlex.split(cmd))
-            cmd2 = 'git -C {} checkout {}'.format(self.__local, version)
-            shellcmd.run(shlex.split(cmd2))
-        else:
-            cmd += '--branch {} --quiet {} {}'.format(version, self.__remote, self.__local)
-            shellcmd.run(shlex.split(cmd))
+            cmd1 += '--recurse-submodules '
 
-    def checkout(self, version):
-        cmd = self.__git + ' checkout --quiet {}'.format(version)
+        cmd1 += '--quiet {} {}'.format(self.__remote, self.__local)
+        shellcmd.run(shlex.split(cmd1))
+        cmd2 = 'git -C {} checkout --detach {}'.format(self.__local, version)
+        shellcmd.run(shlex.split(cmd2))
+
+    def checkout(self, version, detach=False):
+        cmd = self.__git + ' checkout '
+        if detach:
+           cmd += '--detach '
+        cmd += '--quiet {}'.format(version)
         shellcmd.run(shlex.split(cmd))
 
     def sparsify(self, sparse_config):
@@ -332,7 +331,7 @@ class GitRepository(object):
                 tYpe = 't'
             else:
                 cmd_for_branch = self.__git + ' reflog HEAD -n 1'
-                reflog_output = shellcmd.run(cmd_for_branch.split(), output=True)
+                reflog_output = shellcmd.run(shlex.split(cmd_for_branch), output=True)
                 name = reflog_output.split()[-1].strip()
                 tYpe = 'b'
         elif output.startswith('HEAD'): # Assume hash

--- a/mepo.d/repository/git.py
+++ b/mepo.d/repository/git.py
@@ -45,8 +45,10 @@ class GitRepository(object):
 
         cmd1 += '--quiet {} {}'.format(self.__remote, self.__local)
         shellcmd.run(shlex.split(cmd1))
-        cmd2 = 'git -C {} checkout --detach {}'.format(self.__local, version)
+        cmd2 = 'git -C {} checkout {}'.format(self.__local, version)
         shellcmd.run(shlex.split(cmd2))
+        cmd3 = 'git -C {} checkout --detach'.format(self.__local)
+        shellcmd.run(shlex.split(cmd3))
 
     def checkout(self, version, detach=False):
         cmd = self.__git + ' checkout '
@@ -330,9 +332,11 @@ class GitRepository(object):
                 name = tmp[5:]
                 tYpe = 't'
             else:
-                cmd_for_branch = self.__git + ' reflog HEAD -n 1'
-                reflog_output = shellcmd.run(shlex.split(cmd_for_branch), output=True)
-                name = reflog_output.split()[-1].strip()
+                # This was needed for when we weren't explicitly detaching on clone
+                #cmd_for_branch = self.__git + ' reflog HEAD -n 1'
+                #reflog_output = shellcmd.run(shlex.split(cmd_for_branch), output=True)
+                #name = reflog_output.split()[-1].strip()
+                name = output.split()[-1].strip()
                 tYpe = 'b'
         elif output.startswith('HEAD'): # Assume hash
             cmd = self.__git + ' rev-parse HEAD'

--- a/mepo.d/repository/git.py
+++ b/mepo.d/repository/git.py
@@ -50,6 +50,11 @@ class GitRepository(object):
         cmd3 = 'git -C {} checkout --detach'.format(self.__local)
         shellcmd.run(shlex.split(cmd3))
 
+        # NOTE: The above looks odd because of a quirk of git. You can't do
+        #       git checkout --detach branch unless the branch is local. But
+        #       since this is at clone time, all branches are remote. Thus,
+        #       we have to do a git checkout branch and then detach.
+
     def checkout(self, version, detach=False):
         cmd = self.__git + ' checkout '
         if detach:


### PR DESCRIPTION
This PR should detach branches when doing clone steps.

Also adds `--detach` as an option to `checkout` commands because...why not?