### PR TITLE
Add option to ignore permissions with status and diff

### DIFF
--- a/.github/workflows/mepo.yaml
+++ b/.github/workflows/mepo.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.x, pypy3]
+        python-version: [3.x, pypy-3.8]
 
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
     steps:
@@ -20,6 +20,6 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pyyaml
+        pip install -r requirements.txt
     - name: Run unit tests
       run: python mepo.d/utest/test_mepo_commands.py -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `--ignore-permissions` flag to `status` to allow the command to ignore permissions changes
+
 ### Changed
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added `--ignore-permissions` flag to `status` to allow the command to ignore permissions changes
+- Added `--ignore-permissions` flag to `status` and `diff` to allow the commands to ignore permissions changes
+- Add `--name-status` flag to `mepo diff`
 
 ### Changed
 

--- a/mepo.d/cmdline/parser.py
+++ b/mepo.d/cmdline/parser.py
@@ -117,7 +117,7 @@ class MepoArgParser(object):
         status.add_argument(
             '--ignore-permissions',
             action = 'store_true',
-            help = 'Tells status command to ignore changes in file permissions.')
+            help = 'Tells command to ignore changes in file permissions.')
 
     def __restore_state(self):
         restore_state = self.subparsers.add_parser(
@@ -134,6 +134,14 @@ class MepoArgParser(object):
             '--name-only',
             action = 'store_true',
             help = 'Show only names of changed files')
+        diff.add_argument(
+            '--name-status',
+            action = 'store_true',
+            help = 'Show name-status of changed files')
+        diff.add_argument(
+            '--ignore-permissions',
+            action = 'store_true',
+            help = 'Tells command to ignore changes in file permissions.')
         diff.add_argument(
             '--staged',
             action = 'store_true',

--- a/mepo.d/cmdline/parser.py
+++ b/mepo.d/cmdline/parser.py
@@ -114,6 +114,10 @@ class MepoArgParser(object):
             'status',
             description = 'Check current status of all components',
             aliases=mepoconfig.get_command_alias('status'))
+        status.add_argument(
+            '--ignore-permissions',
+            action = 'store_true',
+            help = 'Tells status command to ignore changes in file permissions.')
 
     def __restore_state(self):
         restore_state = self.subparsers.add_parser(

--- a/mepo.d/command/status/status.py
+++ b/mepo.d/command/status/status.py
@@ -13,10 +13,10 @@ def run(args):
     allcomps = MepoState.read_state()
     pool = mp.Pool()
     atexit.register(pool.close)
-    result = pool.map(check_component_status, allcomps)
+    result = pool.starmap(check_component_status, [(comp, args.ignore_permissions) for comp in allcomps])
     print_status(allcomps, result)
 
-def check_component_status(comp):
+def check_component_status(comp, ignore):
     git = GitRepository(comp.remote, comp.local)
 
     # version_to_string can strip off 'origin/' for display purposes
@@ -30,7 +30,7 @@ def check_component_status(comp):
     # This command is to try and work with git tag oddities
     curr_ver = sanitize_version_string(orig_ver,curr_ver,git)
 
-    return (curr_ver, internal_state_branch_name, git.check_status())
+    return (curr_ver, internal_state_branch_name, git.check_status(ignore))
 
 def print_status(allcomps, result):
     orig_width = len(max([comp.name for comp in allcomps], key=len))

--- a/mepo.d/repository/git.py
+++ b/mepo.d/repository/git.py
@@ -112,9 +112,14 @@ class GitRepository(object):
         return output.rstrip()
 
     def run_diff(self, args=None):
-        cmd = self.__git + ' diff --color'
+        cmd = 'git -C {}'.format(self.__full_local_path)
+        if args.ignore_permissions:
+            cmd += ' -c core.fileMode=false'
+        cmd += ' diff --color'
         if args.name_only:
             cmd += ' --name-only'
+        if args.name_status:
+            cmd += ' --name-status'
         if args.staged:
             cmd += ' --staged'
         output = shellcmd.run(shlex.split(cmd),output=True)
@@ -174,7 +179,7 @@ class GitRepository(object):
     def check_status(self, ignore_permissions=False):
         cmd = 'git -C {}'.format(self.__full_local_path)
         if ignore_permissions:
-            cmd += ' -c core.fileMode=false '
+            cmd += ' -c core.fileMode=false'
         cmd += ' status --porcelain=v2'
         output = shellcmd.run(shlex.split(cmd), output=True)
         if output.strip():

--- a/mepo.d/repository/git.py
+++ b/mepo.d/repository/git.py
@@ -171,8 +171,11 @@ class GitRepository(object):
         status = shellcmd.run(shlex.split(cmd),status=True)
         return status
 
-    def check_status(self):
-        cmd = self.__git + ' status --porcelain=v2'
+    def check_status(self, ignore_permissions=False):
+        cmd = 'git -C {}'.format(self.__full_local_path)
+        if ignore_permissions:
+            cmd += ' -c core.fileMode=false '
+        cmd += ' status --porcelain=v2'
         output = shellcmd.run(shlex.split(cmd), output=True)
         if output.strip():
             output_list = output.splitlines()

--- a/mepo.d/utest/test_mepo_commands.py
+++ b/mepo.d/utest/test_mepo_commands.py
@@ -64,6 +64,7 @@ class TestMepoCommands(unittest.TestCase):
 
     def test_status(self):
         sys.stdout = output = StringIO()
+        args.ignore_permissions=False
         mepo_status.run(args)
         sys.stdout = sys.__stdout__
         with open(os.path.join(self.__class__.output_dir, 'status_output.txt'), 'r') as fin:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-PyYAML==5.4
+PyYAML>=5.4


### PR DESCRIPTION
This PR adds a new option to `mepo status` and `mepo diff`. The issue is that sometimes when helping users, they need to give read permission to a model clone to get help. But if they decided to do a `chmod 777` then `git` will see all sorts of changes. For example:
```console
❯ gh repo clone GEOS-ESM/ESMA_env
❯ git -C ESMA_env status --porcelain=v2
❯ chmod -R 777 ESMA_env
❯ git -C ESMA_env status --porcelain=v2
1 .M N... 100644 100644 100755 38265f565f397fff5069aa3425289e6fa2d042f0 38265f565f397fff5069aa3425289e6fa2d042f0 .github/workflows/changelog-enforcer.yml
1 .M N... 100644 100644 100755 b25c15b81fae06e1c55946ac6270bfdb293870e8 b25c15b81fae06e1c55946ac6270bfdb293870e8 .gitignore
1 .M N... 100644 100644 100755 0c075a78b7d1eda40090ce65dbf557908a581e8b 0c075a78b7d1eda40090ce65dbf557908a581e8b BASEDIR.rc.in
1 .M N... 100644 100644 100755 46b8ae96b2be6761fcf75797356bbfb18b3226a0 46b8ae96b2be6761fcf75797356bbfb18b3226a0 BUILD_MODULES.rc.in
1 .M N... 100644 100644 100755 c0b280170574b74100ee12a59aa86aba917c9de0 c0b280170574b74100ee12a59aa86aba917c9de0 CHANGELOG.md
1 .M N... 100644 100644 100755 63c711f775196666ea5c2da1493cec7f5f0f2db6 63c711f775196666ea5c2da1493cec7f5f0f2db6 CMAKE_VERSION.rc.in
1 .M N... 100644 100644 100755 e86e944cc5e64fb42401b3726d87f83c74bb49f2 e86e944cc5e64fb42401b3726d87f83c74bb49f2 CMakeLists.txt
1 .M N... 100644 100644 100755 704e6d1f7d74274fe3e9c7e623229eabe0b92358 704e6d1f7d74274fe3e9c7e623229eabe0b92358 CODE_OF_CONDUCT.md
1 .M N... 100644 100644 100755 13724167a7d31cc7427d04dc10af53d4d750c43c 13724167a7d31cc7427d04dc10af53d4d750c43c CONTRIBUTING.md
1 .M N... 100644 100644 100755 26a5bfb06514e06ea838acfd377e4c37c60c1605 26a5bfb06514e06ea838acfd377e4c37c60c1605 COPYRIGHT
1 .M N... 100644 100644 100755 41e970358ad79d6e0a7671273b7f4f05a03fa009 41e970358ad79d6e0a7671273b7f4f05a03fa009 GIT_VERSION.rc.in
1 .M N... 100644 100644 100755 82ca45048cafeb8adf9479569c652dcf62c67637 82ca45048cafeb8adf9479569c652dcf62c67637 LICENSE
1 .M N... 100644 100644 100755 cf008bf9c0cf0aa38a6b316cd1ee6ad6aaa7c074 cf008bf9c0cf0aa38a6b316cd1ee6ad6aaa7c074 LICENSE-NOSA
1 .M N... 100644 100644 100755 2009fefe78a785edc0e19a4d0068153e6509ab4a 2009fefe78a785edc0e19a4d0068153e6509ab4a README.md
1 .M N... 100644 100644 100755 cb7fc73423f526c090ad0666e4a6a5a9c9da6371 cb7fc73423f526c090ad0666e4a6a5a9c9da6371 SITE.rc.in
1 .M N... 100644 100644 100755 5ee327e8a2175d76a8f96ea30800e0924480edb3 5ee327e8a2175d76a8f96ea30800e0924480edb3 g5_modules.sh
1 .M N... 100644 100644 100755 4fe8c6f075f3a9a2972491e7cf818604752282d6 4fe8c6f075f3a9a2972491e7cf818604752282d6 g5_modules.zsh
```
So nothing really changed but the permissions. `git` has a way to ignore that:
```console
❯ git -C ESMA_env -c core.fileMode=false status --porcelain=v2
❯
```

So this PR adds a `--ignore-permissions` option to `mepo status` and `mepo diff` to allow for "ignoring" this case. (Of course, use with caution!)