### PR TITLE
Add ignore-case option to mepo whereis, update mepo-cd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [1.40.0] - 2022-01-11
+
+### Added
+
+- Added `--ignore-case` option to `mepo whereis`
+
+### Changed
+
+- Updated `mepo-cd` functions and aliases to use ignore-case variant of `mepo whereis --ignore-case` by default
+  - This allows for simpler use of `mepo-cd` as you don't have to exactly match the name of a component
+
 ## [1.39.0] - 2022-01-07
 
 ### Added

--- a/etc/mepo-cd.bash
+++ b/etc/mepo-cd.bash
@@ -18,7 +18,7 @@ function mepo-cd () {
     if [ "$#" -eq 0 ]; then
        output=$(mepo whereis _root)
     else
-       output=$(mepo whereis $1)
+       output=$(mepo whereis -i $1)
     fi
     if [ $? -eq 0 ]; then
         cd $output

--- a/etc/mepo-cd.csh
+++ b/etc/mepo-cd.csh
@@ -1,1 +1,1 @@
-alias mepo-cd 'cd `mepo whereis \!:1`'
+alias mepo-cd 'cd `mepo whereis -i \!:1`'

--- a/etc/mepo-cd.zsh
+++ b/etc/mepo-cd.zsh
@@ -18,7 +18,7 @@ function mepo-cd () {
   if (( $# == 0 )); then
      output=$(mepo whereis _root)
   else
-     output=$(mepo whereis $1)
+     output=$(mepo whereis -i $1)
   fi
   if [ $? -eq 0 ]; then
      cd $output

--- a/mepo.d/cmdline/parser.py
+++ b/mepo.d/cmdline/parser.py
@@ -312,6 +312,10 @@ class MepoArgParser(object):
             nargs = '?',
             default = None,
             help = "Component to get location of")
+        whereis.add_argument(
+            '-i','--ignore-case',
+            action = 'store_true',
+            help = 'Ignore case for whereis')
 
     def __stage(self):
         stage = self.subparsers.add_parser(

--- a/mepo.d/command/diff/diff.py
+++ b/mepo.d/command/diff/diff.py
@@ -42,6 +42,15 @@ def print_diff(comp, args, output):
         print(line.rstrip())
     print(horiz_line)
 
-def _get_relative_path(path):
-    full_local_path = os.path.join(MepoState.get_root_dir(),comp.local)
+def _get_relative_path(local_path):
+    """
+    Get the relative path when given a local path.
+
+    local_path: The path to a subrepo as known by mepo (relative to the .mepo directory)
+    """
+
+    # This creates a full path on the disk from the root of mepo and the local_path
+    full_local_path=os.path.join(MepoState.get_root_dir(),local_path)
+
+    # We return the path relative to where we currently are
     return os.path.relpath(full_local_path, os.getcwd())

--- a/mepo.d/command/diff/diff.py
+++ b/mepo.d/command/diff/diff.py
@@ -34,10 +34,8 @@ def check_component_diff(comp, args):
 def print_diff(comp, args, output):
     columns, lines = get_terminal_size(fallback=(80,20))
     horiz_line = u'\u2500'*columns
-    
-    root_dir = MepoState.get_root_dir()
-    full_local_path = os.path.join(root_dir,comp.local)
-    print("{} (location: {}):".format(comp.name,_get_relative_path(full_local_path)))
+
+    print("{} (location: {}):".format(comp.name,_get_relative_path(comp.local)))
     print()
     for line in output.split('\n'):
         #print('   |', line.rstrip())
@@ -45,4 +43,5 @@ def print_diff(comp, args, output):
     print(horiz_line)
 
 def _get_relative_path(path):
-    return os.path.relpath(path, os.getcwd())
+    full_local_path = os.path.join(MepoState.get_root_dir(),comp.local)
+    return os.path.relpath(full_local_path, os.getcwd())

--- a/mepo.d/command/whereis/whereis.py
+++ b/mepo.d/command/whereis/whereis.py
@@ -4,25 +4,41 @@ from state.state import MepoState
 from utilities import verify
 
 def run(args):
-    root_dir = MepoState.get_root_dir()
     allcomps = MepoState.read_state()
     if args.comp_name: # single comp name is specified, print relpath
         if args.comp_name == "_root":
             # _root is a "hidden" allowed argument for whereis to return
             # the root dir of the project. Mainly used by mepo-cd
-            print(root_dir)
+            print(MepoState.get_root_dir())
         else:
-            verify.valid_components([args.comp_name], allcomps)
+            # Verify that we passed in a good component name
+            verify.valid_components([args.comp_name], allcomps, ignore_case=args.ignore_case)
+
+            # Create a name to look for according to ignore_case option
+            component_to_find = args.comp_name.casefold() if args.ignore_case else args.comp_name
+
+            # Loop over all the components that mepo knows about...
             for comp in allcomps:
-                if comp.name == args.comp_name:
-                    full_local_path=os.path.join(root_dir,comp.local)
-                    print(_get_relative_path(full_local_path))
+                # Create a name to compare to based on ignore_case option
+                component_in_allcomps = comp.name.casefold() if args.ignore_case else comp.name
+                # And if they match, print the relative path
+                if component_in_allcomps == component_to_find: print(_get_relative_path(comp.local))
+
     else: # print relpaths of all comps
         max_namelen = len(max([x.name for x in allcomps], key=len))
         FMT = '{:<%s.%ss} | {:<s}' % (max_namelen, max_namelen)
         for comp in allcomps:
-            full_local_path=os.path.join(root_dir,comp.local)
-            print(FMT.format(comp.name, _get_relative_path(full_local_path)))
-        
-def _get_relative_path(path):
-    return os.path.relpath(path, os.getcwd())
+            print(FMT.format(comp.name, _get_relative_path(comp.local)))
+
+def _get_relative_path(local_path):
+    """
+    Get the relative path when given a local path.
+
+    local_path: The path to a subrepo as known by mepo (relative to the .mepo directory)
+    """
+
+    # This creates a full path on the disk from the root of mepo and the local_path
+    full_local_path=os.path.join(MepoState.get_root_dir(),local_path)
+
+    # We return the path relative to where we currently are
+    return os.path.relpath(full_local_path, os.getcwd())

--- a/mepo.d/utilities/verify.py
+++ b/mepo.d/utilities/verify.py
@@ -1,5 +1,35 @@
-def valid_components(specified_comp_names, allcomps):
-    allnames = [x.name for x in allcomps]
-    for compname in specified_comp_names:
-        if compname not in allnames:
-            raise Exception('Unknown component name [{}]'.format(compname))
+def valid_components(specified_comp_names, allcomps, ignore_case=False):
+    """
+    Validate a component name
+
+    Arguments:
+        specified_comp_names: List of component names
+        allcomps: List of all components known to mepo
+
+    Keyword arguments:
+        ignore_case: should the comparison ignore case
+    """
+
+    # Make a list of all the component names depending on ignore_case
+    all_component_names = [x.name.casefold() if ignore_case else x.name for x in allcomps]
+
+    # Loop over all the components we want to verify...
+    for component_name in specified_comp_names:
+
+        # Create a name to compare with based on ignore_case
+        component_to_find = component_name.casefold() if ignore_case else component_name
+
+        # Validate the component
+        _validate_component(component_to_find, all_component_names)
+
+def _validate_component(component, all_components):
+    """
+    Function to raise exception on invalid component name
+
+    Arguments:
+        component: component to validate
+        all_components: List of valid components
+    """
+
+    if component not in all_components:
+        raise Exception('Unknown component name [{}]'.format(component))


### PR DESCRIPTION
This PR adds a new option to `mepo whereis`, `--ignore-case` (or `-i`). This option, as it says, allows for a user to ignore the case of the component for `whereis`:
```console
❯ mepo whereis mapl
Traceback (most recent call last):
  File "/Users/mathomp4/bin/mepo", line 17, in <module>
    main()
  File "/Users/mathomp4/mepo/mepo.d/main.py", line 6, in main
    command.run(args)
  File "/Users/mathomp4/mepo/mepo.d/command/command.py", line 11, in run
    cmd_module.run(args)
  File "/Users/mathomp4/mepo/mepo.d/command/whereis/whereis.py", line 15, in run
    verify.valid_components([args.comp_name], allcomps, ignore_case=args.ignore_case)
  File "/Users/mathomp4/mepo/mepo.d/utilities/verify.py", line 23, in valid_components
    _validate_component(component_to_find, all_component_names)
  File "/Users/mathomp4/mepo/mepo.d/utilities/verify.py", line 35, in _validate_component
    raise Exception('Unknown component name [{}]'.format(component))
Exception: Unknown component name [mapl]
❯ mepo whereis -i mapl
src/Shared/@MAPL
```

The main use of this is in the `mepo-cd` helper functions/aliases where now a user doesn't need to know the exact case of a component:
```console
❯ pwd
/Users/mathomp4/Models/GEOSgcm-Intel2022.0-NewBaselib/GEOSgcm
❯ mepo-cd geoschem_gridcomp
❯ pwd
/Users/mathomp4/Models/GEOSgcm-Intel2022.0-NewBaselib/GEOSgcm/src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp
```