### PR TITLE
Fix mepo compare output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-## [1.40.0] - 2022-01-11
+## [1.40.0] - 2022-01-12
+
+### Fixed
+
+- Fixed the output of `mepo compare` to handle detached branch hashes
 
 ### Added
 

--- a/mepo.d/command/compare/compare.py
+++ b/mepo.d/command/compare/compare.py
@@ -8,8 +8,7 @@ VER_LEN = 30
 
 def run(args):
     allcomps = MepoState.read_state()
-    max_namelen = len(max([x.name for x in allcomps], key=len))
-    max_origlen = len(max([version_to_string(x.version) for x in allcomps], key=len))
+    max_namelen, max_origlen = calculate_header_lengths(allcomps)
     print_header(max_namelen, max_origlen)
     for comp in allcomps:
         git = GitRepository(comp.remote, comp.local)
@@ -20,6 +19,17 @@ def run(args):
         curr_ver = sanitize_version_string(orig_ver,curr_ver,git)
 
         print_cmp(comp.name, orig_ver, curr_ver, max_namelen, max_origlen)
+
+def calculate_header_lengths(allcomps):
+    names = []
+    versions = []
+    for comp in allcomps:
+        git = GitRepository(comp.remote, comp.local)
+        names.append(comp.name)
+        versions.append(version_to_string(comp.version,git))
+    max_namelen = len(max(names, key=len))
+    max_origlen = len(max(versions, key=len))
+    return max_namelen, max_origlen
 
 def print_header(max_namelen, max_origlen):
     FMT_VAL = (max_namelen, max_namelen, max_origlen)


### PR DESCRIPTION
The change to add the hashes to `mepo compare` output broke the nice looking table. This fixes that.