### PR TITLE
Make compare brief by default, add --all option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `--brief` option to `compare` to only show differing repos
+
 ### Changed
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `--brief` option to `compare` to only show differing repos
-
 ### Changed
+
+- Changed the default behavior of `compare` to only show differing repos. Use `--all` to see all repos
 
 ### Removed
 

--- a/mepo.d/cmdline/parser.py
+++ b/mepo.d/cmdline/parser.py
@@ -296,12 +296,13 @@ class MepoArgParser(object):
     def __compare(self):
         compare = self.subparsers.add_parser(
             'compare',
-            description = 'Compare current and original states of all components',
+            description = 'Compare current and original states of all components. '
+                          'Will only show differing repos unless --all is passed in',
             aliases=mepoconfig.get_command_alias('compare'))
         compare.add_argument(
-            '--brief',
+            '--all',
             action = 'store_true',
-            help = 'Only show differing repos')
+            help = 'Show all repos, not only differing repos')
 
     def __whereis(self):
         whereis = self.subparsers.add_parser(

--- a/mepo.d/cmdline/parser.py
+++ b/mepo.d/cmdline/parser.py
@@ -298,6 +298,10 @@ class MepoArgParser(object):
             'compare',
             description = 'Compare current and original states of all components',
             aliases=mepoconfig.get_command_alias('compare'))
+        compare.add_argument(
+            '--brief',
+            action = 'store_true',
+            help = 'Only show differing repos')
 
     def __whereis(self):
         whereis = self.subparsers.add_parser(

--- a/mepo.d/command/compare/compare.py
+++ b/mepo.d/command/compare/compare.py
@@ -18,7 +18,7 @@ def run(args):
         # This command is to try and work with git tag oddities
         curr_ver = sanitize_version_string(orig_ver,curr_ver,git)
 
-        print_cmp(comp.name, orig_ver, curr_ver, max_namelen, max_origlen)
+        print_cmp(comp.name, orig_ver, curr_ver, max_namelen, max_origlen, args.brief)
 
 def calculate_header_lengths(allcomps):
     names = []
@@ -37,13 +37,17 @@ def print_header(max_namelen, max_origlen):
     print(FMTHEAD.format("Repo","Original","Current"))
     print(FMTHEAD.format("-"*80,"-"*max_origlen,"-"*7))
 
-def print_cmp(name, orig, curr, name_width, orig_width):
+def print_cmp(name, orig, curr, name_width, orig_width, brief):
     name_blank = ''
     #if orig not in curr:
     if curr not in orig:
         name = colors.RED + name + colors.RESET
         name_blank = colors.RED + name_blank + colors.RESET
         name_width += len(colors.RED) + len(colors.RESET)
+    else:
+        # This only prints differing repos if --brief is passed in
+        if brief:
+            return
     FMT_VAL = (name_width, name_width, orig_width)
 
     FMT0 = '{:<%s.%ss} | {:<%ss} | {:<s}' % FMT_VAL


### PR DESCRIPTION
This PR changes the default behavior of `mepo compare`. Now, `mepo compare` will only show differing repos:
```
❯ mepo compare
Repo                   | Original                         | Current
---------------------- | -------------------------------- | -------
env                    | (t) v3.11.0 (DH)                 | (b) main
cmake                  | (t) v3.10.0 (DH)                 | (b) develop
MAPL                   | (t) v2.17.2 (DH)                 | (b) develop
```
To see all repos, use `--all`:
```
❯ mepo compare --all
Repo                   | Original                         | Current
---------------------- | -------------------------------- | -------
GEOSgcm                | (b) main                         | (b) main
env                    | (t) v3.11.0 (DH)                 | (b) main
cmake                  | (t) v3.10.0 (DH)                 | (b) develop
ecbuild                | (t) geos/v1.2.0 (DH)             | (t) geos/v1.2.0 (DH)
NCEP_Shared            | (t) v1.2.0 (DH)                  | (t) v1.2.0 (DH)
GMAO_Shared            | (t) v1.5.1 (DH)                  | (t) v1.5.1 (DH)
MAPL                   | (t) v2.17.2 (DH)                 | (b) develop
FMS                    | (t) geos/2019.01.02+noaff.7 (DH) | (t) geos/2019.01.02+noaff.7 (DH)
GEOSgcm_GridComp       | (t) v1.15.0 (DH)                 | (t) v1.15.0 (DH)
FVdycoreCubed_GridComp | (t) v1.6.0 (DH)                  | (t) v1.6.0 (DH)
fvdycore               | (t) geos/v1.3.0 (DH)             | (t) geos/v1.3.0 (DH)
GEOSchem_GridComp      | (t) v1.8.1 (DH)                  | (t) v1.8.1 (DH)
HEMCO                  | (t) geos/v2.2.2 (DH)             | (t) geos/v2.2.2 (DH)
geos-chem              | (t) geos/v13.0.0-rc1 (DH)        | (t) geos/v13.0.0-rc1 (DH)
GOCART                 | (t) v2.0.4 (DH)                  | (t) v2.0.4 (DH)
mom                    | (t) geos/5.1.0+1.2.0 (DH)        | (t) geos/5.1.0+1.2.0 (DH)
mom6                   | (t) geos/v2.0.2 (DH)             | (t) geos/v2.0.2 (DH)
RRTMGP                 | (t) geos/v1.5+1.0.0 (DH)         | (t) geos/v1.5+1.0.0 (DH)
GEOSgcm_App            | (t) v1.7.0 (DH)                  | (t) v1.7.0 (DH)
UMD_Etc                | (t) v1.0.4 (DH)                  | (t) v1.0.4 (DH)
CPLFCST_Etc            | (t) v1.0.1 (DH)                  | (t) v1.0.1 (DH)
```

If no repos differ, you see:
```
❯ mepo compare
No repositories have changed
❯ mepo compare --all
No repositories have changed
```