### PR TITLE
Add whitespace ignore to diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [1.42.0] - 2022-03-29
+
+### Added
+
+- Added `-b/--ignore-space-change` option to `mepo diff`
+
 ## [1.41.0] - 2022-03-25
 
 ### Changed

--- a/mepo.d/cmdline/parser.py
+++ b/mepo.d/cmdline/parser.py
@@ -151,6 +151,10 @@ class MepoArgParser(object):
             action = 'store_true',
             help = 'Show diff of staged changes')
         diff.add_argument(
+            '-b','--ignore-space-change',
+            action = 'store_true',
+            help = 'Ignore changes in amount of whitespace')
+        diff.add_argument(
             'comp_name',
             metavar = 'comp-name',
             nargs = '*',

--- a/mepo.d/repository/git.py
+++ b/mepo.d/repository/git.py
@@ -128,6 +128,8 @@ class GitRepository(object):
             cmd += ' --name-status'
         if args.staged:
             cmd += ' --staged'
+        if args.ignore_space_change:
+            cmd += ' --ignore-space-change'
         output = shellcmd.run(shlex.split(cmd),output=True)
         return output.rstrip()
 


### PR DESCRIPTION
This PR adds a `-b`/`--ignore-space-change` flag to the `mepo diff` command, a la `git diff -b`. This allows diffing to ignore whitespace changes. 