### PR TITLE
Fixes #224. Fix for running mepo clone more than once

### DIFF
--- a/.github/workflows/mepo.yaml
+++ b/.github/workflows/mepo.yaml
@@ -24,7 +24,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-      timeout-minutes: 1
+      timeout-minutes: 2
 
     - name: Run unit tests
       run: python3 mepo.d/utest/test_mepo_commands.py -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [1.43.0] - 2022-04-18
+
+### Fixed
+
+- Fixed issue where you could issue `mepo clone` in already cloned multirepos (#224)
+
+### Changed
+
+- Changed StateDoesNotExistError and StateAlreadyInitializedError to be subclasses of `SystemExit`
+- Changed some git subcommands to use full local path
+
 ## [1.42.0] - 2022-03-29
 
 ### Added

--- a/mepo.d/command/clone/clone.py
+++ b/mepo.d/command/clone/clone.py
@@ -71,7 +71,7 @@ def run(args):
             recurse = comp.recurse_submodules
             # We need the type to handle hashes in components.yaml
             type = comp.version.type
-            git.clone(version,recurse,type)
+            git.clone(version,recurse,type,comp.name)
             if comp.sparse:
                 git.sparsify(comp.sparse)
             print_clone_info(comp, max_namelen)

--- a/mepo.d/repository/git.py
+++ b/mepo.d/repository/git.py
@@ -7,6 +7,7 @@ from state.state import MepoState
 from utilities import shellcmd
 from utilities import colors
 from urllib.parse import urljoin
+from state.exceptions import RepoAlreadyClonedError
 
 class GitRepository(object):
     """
@@ -38,16 +39,20 @@ class GitRepository(object):
     def get_remote_url(self):
         return self.__remote
 
-    def clone(self, version, recurse, type):
+    def clone(self, version, recurse, type, comp_name):
         cmd1 = 'git clone '
         if recurse:
             cmd1 += '--recurse-submodules '
 
-        cmd1 += '--quiet {} {}'.format(self.__remote, self.__local)
-        shellcmd.run(shlex.split(cmd1))
-        cmd2 = 'git -C {} checkout {}'.format(self.__local, version)
+        cmd1 += '--quiet {} {}'.format(self.__remote, self.__full_local_path)
+        try:
+            shellcmd.run(shlex.split(cmd1))
+        except subprocess.CalledProcessError:
+            raise RepoAlreadyClonedError(f'Error! Repo [{comp_name}] already cloned')
+
+        cmd2 = 'git -C {} checkout {}'.format(self.__full_local_path, version)
         shellcmd.run(shlex.split(cmd2))
-        cmd3 = 'git -C {} checkout --detach'.format(self.__local)
+        cmd3 = 'git -C {} checkout --detach'.format(self.__full_local_path)
         shellcmd.run(shlex.split(cmd3))
 
         # NOTE: The above looks odd because of a quirk of git. You can't do
@@ -64,7 +69,7 @@ class GitRepository(object):
            shellcmd.run(shlex.split(cmd2))
 
     def sparsify(self, sparse_config):
-        dst = os.path.join(self.__local, '.git', 'info', 'sparse-checkout')
+        dst = os.path.join(self.__full_local_path, '.git', 'info', 'sparse-checkout')
         os.makedirs(os.path.dirname(dst), exist_ok=True)
         shutil.copy(sparse_config, dst)
         cmd1 = self.__git + ' config core.sparseCheckout true'

--- a/mepo.d/repository/git.py
+++ b/mepo.d/repository/git.py
@@ -26,7 +26,7 @@ class GitRepository(object):
             self.__remote = remote_url
 
         root_dir = MepoState.get_root_dir()
-        full_local_path=os.path.join(root_dir,local_path)
+        full_local_path=os.path.normpath(os.path.join(root_dir,local_path))
         self.__full_local_path=full_local_path
         self.__git = 'git -C "{}"'.format(self.__full_local_path)
 

--- a/mepo.d/state/exceptions.py
+++ b/mepo.d/state/exceptions.py
@@ -1,9 +1,13 @@
-class StateDoesNotExistError(Exception):
+class StateDoesNotExistError(SystemExit):
     """Raised when the mepo state does not exist"""
     pass
 
-class StateAlreadyInitializedError(Exception):
+class StateAlreadyInitializedError(SystemExit):
     """Raised when the mepo state has already been initialized"""
+    pass
+
+class RepoAlreadyClonedError(SystemExit):
+    """Raised when the repository has already been cloned"""
     pass
 
 class ConfigFileNotFoundError(FileNotFoundError):

--- a/mepo.d/state/state.py
+++ b/mepo.d/state/state.py
@@ -55,7 +55,7 @@ class MepoState(object):
     @classmethod
     def initialize(cls, project_config_file, directory_style):
         if cls.exists():
-            raise StateAlreadyInitializedError('mepo state already exists')
+            raise StateAlreadyInitializedError('Error! mepo state already exists')
         input_components = ConfigFile(project_config_file).read_file()
 
         num_fixture = 0
@@ -73,7 +73,7 @@ class MepoState(object):
     @classmethod
     def read_state(cls):
         if not cls.exists():
-            raise StateDoesNotExistError('mepo state does not exist')
+            raise StateDoesNotExistError('Error! mepo state does not exist')
         with open(cls.get_file(), 'rb') as fin:
             allcomps = pickle.load(fin)
         return allcomps


### PR DESCRIPTION
Closes #224 

This fixes a bug in mepo running `mepo clone`. First, it makes the error a bit more clear when you try to `mepo clone` in a fixture already cloned (see #224):
```console
$ mepo clone git@github.com:GEOS-ESM/MAPL.git
Initializing mepo using components.yaml
ESMA_env   | (t) v3.11.0
ESMA_cmake | (t) v3.10.0
ecbuild    | (t) geos/v1.2.0
$ cd MAPL
$ mepo clone
fatal: destination path '/Users/mathomp4/Models/MAPL/ESMA_env' already exists and is not an empty directory.

Error! Repo [ESMA_env] already cloned
```

Note it will always error out with the first repo `mepo` tries to clone again.

But, it also fixes a bug where you could re-`mepo clone` in *any subdirectory*! For example this:
```console
$ mepo clone git@github.com:GEOS-ESM/MAPL.git
Initializing mepo using components.yaml
ESMA_env   | (t) v3.11.0
ESMA_cmake | (t) v3.10.0
ecbuild    | (t) geos/v1.2.0
$ cd MAPL/shared
$ mepo clone
ESMA_env   | (t) v3.11.0
ESMA_cmake | (t) v3.10.0
ecbuild    | (t) geos/v1.2.0
```
should be an obvious failure. But, nope, there was a bug in the code such that what you'd get is an entire new set of subrepos in that subdirectory!

Now the failure is more obvious:
```console
$ mepo clone git@github.com:GEOS-ESM/MAPL.git
Initializing mepo using components.yaml
ESMA_env   | (t) v3.11.0
ESMA_cmake | (t) v3.10.0
ecbuild    | (t) geos/v1.2.0
$ cd MAPL/shared
$ mepo clone
fatal: destination path '/Users/mathomp4/Models/MAPL/ESMA_env' already exists and is not an empty directory.

Error! Repo [ESMA_env] already cloned
```