### PR TITLE
Fixes #228. Add typechange support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [1.44.0] - 2022-04-28
+
+### Fixed
+
+- Add support for typechange in `mepo status`
+
 ## [1.43.0] - 2022-04-18
 
 ### Fixed

--- a/mepo.d/repository/git.py
+++ b/mepo.d/repository/git.py
@@ -222,6 +222,8 @@ class GitRepository(object):
                     verbose_status = colors.RED   + "modified, not staged" + colors.RESET
                 elif short_status == ".A":
                     verbose_status = colors.RED   + "added, not staged" + colors.RESET
+                elif short_status == ".T":
+                    verbose_status = colors.RED   + "typechange, not staged" + colors.RESET
 
                 elif short_status == "D.":
                     verbose_status = colors.GREEN + "deleted, staged" + colors.RESET
@@ -229,6 +231,8 @@ class GitRepository(object):
                     verbose_status = colors.GREEN + "modified, staged" + colors.RESET
                 elif short_status == "A.":
                     verbose_status = colors.GREEN + "added, staged" + colors.RESET
+                elif short_status == "T.":
+                    verbose_status = colors.GREEN + "typechange, staged" + colors.RESET
 
                 elif short_status == "MM":
                     verbose_status = colors.GREEN + "modified, staged" + colors.RESET + " with " + colors.RED + "unstaged changes" + colors.RESET
@@ -239,6 +243,11 @@ class GitRepository(object):
                     verbose_status = colors.GREEN + "added, staged" + colors.RESET + " with " + colors.RED + "unstaged changes" + colors.RESET
                 elif short_status == "AD":
                     verbose_status = colors.GREEN + "added, staged" + colors.RESET + " but " + colors.RED + "deleted, not staged" + colors.RESET
+
+                elif short_status == "TM":
+                    verbose_status = colors.GREEN + "typechange, staged" + colors.RESET + " with " + colors.RED + "unstaged changes" + colors.RESET
+                elif short_status == "TD":
+                    verbose_status = colors.GREEN + "typechange, staged" + colors.RESET + " but " + colors.RED + "deleted, not staged" + colors.RESET
 
                 elif short_status == "R.":
                     verbose_status = colors.GREEN + "renamed" + colors.RESET + " as " + colors.YELLOW + new_file_name + colors.RESET


### PR DESCRIPTION
This PR adds support for typechange commits. At the moment, `mepo status` will say:
```
GOCART      | (b) main
   | ESMF/GOCART2G_GridComp/DU2G_GridComp/AMIP.20C/DU2G_instance_DU.rc: unknown (please contact mepo maintainer)
```
because it doesn't know about this. But with this PR we can now translate those:
```
GOCART      | (b) main
   | ESMF/GOCART2G_GridComp/DU2G_GridComp/AMIP.20C/DU2G_instance_DU.rc: typechange, staged but deleted, not staged
```

Note this might not be a complete support for typechange, but at least should cover the "main" commits.