### PR TITLE
Allow checkout-if-exists to work on tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Allow `checkout-if-exists` to work on tags or branches
+
 ### Removed
 
 ## [1.44.0] - 2022-04-28

--- a/mepo.d/cmdline/parser.py
+++ b/mepo.d/cmdline/parser.py
@@ -192,12 +192,12 @@ class MepoArgParser(object):
     def __checkout_if_exists(self):
         checkout_if_exists = self.subparsers.add_parser(
             'checkout-if-exists',
-            description = 'Switch to branch `branch-name` in any component where it is present. ',
+            description = 'Switch to branch or tag `ref-name` in any component where it is present. ',
             aliases=mepoconfig.get_command_alias('checkout-if-exists'))
         checkout_if_exists.add_argument(
-            'branch_name',
-            metavar = 'branch-name',
-            help = "Name of branch")
+            'ref_name',
+            metavar = 'ref-name',
+            help = "Name of branch or tag")
         checkout_if_exists.add_argument(
             '-q', '--quiet',
             action = 'store_true',

--- a/mepo.d/command/checkout-if-exists/checkout-if-exists.py
+++ b/mepo.d/command/checkout-if-exists/checkout-if-exists.py
@@ -7,17 +7,19 @@ def run(args):
     allcomps = MepoState.read_state()
     for comp in allcomps:
         git = GitRepository(comp.remote, comp.local)
-        branch = args.branch_name
-        status = git.verify_branch(branch)
+        ref_name = args.ref_name
+        status, ref_type = git.verify_branch_or_tag(ref_name)
 
         if status == 0:
             if args.dry_run:
-                print("Branch %s exists in %s" %
-                        (colors.YELLOW + branch + colors.RESET,
+                print("%s %s exists in %s" %
+                        (ref_type,
+                         colors.YELLOW + ref_name + colors.RESET,
                          colors.RESET + comp.name + colors.RESET))
             else:
                 if not args.quiet:
-                    print("Checking out branch %s in %s" %
-                            (colors.YELLOW + branch + colors.RESET,
-                            colors.RESET + comp.name + colors.RESET))
-                git.checkout(branch,args.detach)
+                    print("Checking out %s %s in %s" %
+                            (ref_type.lower,
+                             colors.YELLOW + ref_name + colors.RESET,
+                             colors.RESET + comp.name + colors.RESET))
+                git.checkout(ref_name,args.detach)

--- a/mepo.d/command/checkout-if-exists/checkout-if-exists.py
+++ b/mepo.d/command/checkout-if-exists/checkout-if-exists.py
@@ -19,7 +19,7 @@ def run(args):
             else:
                 if not args.quiet:
                     print("Checking out %s %s in %s" %
-                            (ref_type.lower,
+                            (ref_type.lower(),
                              colors.YELLOW + ref_name + colors.RESET,
                              colors.RESET + comp.name + colors.RESET))
                 git.checkout(ref_name,args.detach)

--- a/mepo.d/repository/git.py
+++ b/mepo.d/repository/git.py
@@ -184,10 +184,18 @@ class GitRepository(object):
         cmd += ' origin {}'.format(tag_name)
         shellcmd.run(shlex.split(cmd))
 
-    def verify_branch(self, branch_name):
-        cmd = self.__git + ' show-branch remotes/origin/{}'.format(branch_name)
-        status = shellcmd.run(shlex.split(cmd),status=True)
-        return status
+    def verify_branch_or_tag(self, ref_name):
+        branch_cmd = self.__git + f' show-branch remotes/origin/{ref_name}'
+        tag_cmd = self.__git + f' rev-parse {ref_name}'
+        branch_status = shellcmd.run(shlex.split(branch_cmd),status=True)
+        ref_type = "UNKNOWN"
+        if branch_status != 0:
+            status = shellcmd.run(shlex.split(tag_cmd),status=True)
+            ref_type = "Tag"
+        else:
+            status = branch_status
+            ref_type = "Branch"
+        return status, ref_type
 
     def check_status(self, ignore_permissions=False):
         cmd = 'git -C {}'.format(self.__full_local_path)


### PR DESCRIPTION
Closes #231 

This PR now allows for `checkout-if-exists` to work on tags or branches. For a branch:
```
❯ mepo checkout-if-exists feature/mathomp4/add-shared-baselibs-support -n
Branch feature/mathomp4/add-shared-baselibs-support exists in env
Branch feature/mathomp4/add-shared-baselibs-support exists in cmake
Branch feature/mathomp4/add-shared-baselibs-support exists in MAPL
Branch feature/mathomp4/add-shared-baselibs-support exists in GEOSgcm_GridComp
```
and for a tag:
```
❯ mepo checkout-if-exists sdr_r21c_v01 -n
Tag sdr_r21c_v01 exists in GEOSgcm_GridComp
Tag sdr_r21c_v01 exists in GEOSgcm_App
```
Before tags were just ignored.