### PR TITLE
Add ability to display changed files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add new `changed-files` command to list all changed files vs original state
+
 ### Changed
 
 ### Removed

--- a/mepo.d/cmdline/parser.py
+++ b/mepo.d/cmdline/parser.py
@@ -28,6 +28,7 @@ class MepoArgParser(object):
         self.__fetch()
         self.__checkout()
         self.__checkout_if_exists()
+        self.__changed_files()
         self.__branch()
         self.__tag()
         self.__stash()
@@ -210,6 +211,21 @@ class MepoArgParser(object):
             '-n','--dry-run',
             action = 'store_true',
             help = 'Dry-run only (lists repos where branch exists)')
+
+    def __changed_files(self):
+        changed_files = self.subparsers.add_parser(
+            'changed-files',
+            description = 'List files that have changes versus the state. By default runs against all components.',
+            aliases=mepoconfig.get_command_alias('changed-files'))
+        changed_files.add_argument(
+            '--full-path',
+            action = 'store_true',
+            help = 'Print with full path')
+        changed_files.add_argument(
+            'comp_name',
+            metavar = 'comp-name',
+            nargs = '*',
+            help = 'Component to list branches in')
 
     def __fetch(self):
         fetch = self.subparsers.add_parser(

--- a/mepo.d/command/changed-files/changed-files.py
+++ b/mepo.d/command/changed-files/changed-files.py
@@ -1,0 +1,51 @@
+from state.state import MepoState
+from utilities import colors
+from utilities import verify
+from utilities.version import version_to_string, sanitize_version_string
+from repository.git import GitRepository
+from shutil import get_terminal_size
+from state.component import MepoVersion
+import os
+
+VER_LEN = 30
+
+def run(args):
+    allcomps = MepoState.read_state()
+
+    if any_differing_repos(allcomps):
+        comps2diff = _get_comps_to_diff(args.comp_name, allcomps)
+
+        for comp in comps2diff:
+            git = GitRepository(comp.remote, comp.local)
+            orig_ver = version_to_string(comp.version,git).split()[1]
+            orig_type = comp.version.type
+            changed_files = git.get_changed_files(untracked=True, orig_ver=orig_ver, comp_type=orig_type)
+
+            # If there are changed files, print them with the local path
+            if changed_files:
+                for file in changed_files:
+                    if args.full_path:
+                        print(os.path.abspath(os.path.join(comp.local, file)))
+                    else:
+                        print(os.path.join(comp.local, file))
+
+def _get_comps_to_diff(specified_comps, allcomps):
+    comps_to_diff = allcomps
+    if specified_comps:
+        verify.valid_components(specified_comps, allcomps)
+        comps_to_diff = [x for x in allcomps if x.name in specified_comps]
+    return comps_to_diff
+
+def any_differing_repos(allcomps):
+    for comp in allcomps:
+        git = GitRepository(comp.remote, comp.local)
+        curr_ver = version_to_string(git.get_version(),git)
+        orig_ver = version_to_string(comp.version,git)
+
+        # This command is to try and work with git tag oddities
+        curr_ver = sanitize_version_string(orig_ver,curr_ver,git)
+
+        if curr_ver not in orig_ver:
+            return True
+
+    return False

--- a/mepo.d/command/stage/stage.py
+++ b/mepo.d/command/stage/stage.py
@@ -15,7 +15,7 @@ def stage_files(git, comp, untracked=False, commit=False):
     curr_ver = MepoVersion(*git.get_version())
     if curr_ver.detached: # detached head
         raise Exception(f"{comp.name} has detached head! Cannot stage.")
-    for myfile in git.get_changed_files(untracked):
+    for myfile in git.get_changed_files(untracked=untracked):
         git.stage_file(myfile)
         print_output = f"{comp.name}: {myfile}"
         if commit:

--- a/mepo.d/repository/git.py
+++ b/mepo.d/repository/git.py
@@ -283,8 +283,14 @@ class GitRepository(object):
 
         return output.rstrip()
 
-    def __get_modified_files(self):
-        cmd = self.__git + ' diff --name-only'
+    def __get_modified_files(self, orig_ver, comp_type):
+        if not orig_ver:
+            cmd = self.__git + ' diff --name-only'
+        else:
+            if comp_type == "b":
+                cmd = self.__git + ' diff --name-only origin/{}'.format(orig_ver)
+            else:
+                cmd = self.__git + ' diff --name-only {}'.format(orig_ver)
         output = shellcmd.run(shlex.split(cmd), output=True).strip()
         return output.split('\n') if output else []
 
@@ -293,8 +299,8 @@ class GitRepository(object):
         output = shellcmd.run(shlex.split(cmd), output=True).strip()
         return output.split('\n') if output else []
 
-    def get_changed_files(self, untracked=False):
-        changed_files = self.__get_modified_files()
+    def get_changed_files(self, untracked=False, orig_ver=None, comp_type=None):
+        changed_files = self.__get_modified_files(orig_ver, comp_type)
         if untracked:
             changed_files += self.__get_untracked_files()
         return changed_files


### PR DESCRIPTION
This PR adds a new `changed-files` command to mepo. Essentially it will list all files that are different compared to the original tags/branches in the `components.yaml` (technically the mepo state, so if `mepo save` was run, the new `components.yaml`).

For example, if there are no changes:
```bash
❯ mepo compare
No repositories have changed
❯ mepo changed-files
```
Now we checkout a branch:
```bash
❯ mepo develop MAPL
Checking out development branch develop in MAPL
❯ mepo changed-files
./src/Shared/@MAPL/CHANGELOG.md
./src/Shared/@MAPL/generic/MAPL_Generic.F90
```

This shows that compared to where we started, we have two new files. Now let us alter a file and add a file:
```bash
❯ touch foo
❯ echo "bobob" >> src/Components/@GEOSgcm_GridComp/README.md
❯ mepo changed-files
./foo
./src/Shared/@MAPL/CHANGELOG.md
./src/Shared/@MAPL/generic/MAPL_Generic.F90
./src/Components/@GEOSgcm_GridComp/README.md
```

Finally, it has a `--full-path` option for a full path.
```bash
❯ mepo changed-files --full-path
/Users/mathomp4/Models/GEOSgcm-mepo-newfilesvorigin/GEOSgcm/foo
/Users/mathomp4/Models/GEOSgcm-mepo-newfilesvorigin/GEOSgcm/src/Shared/@MAPL/CHANGELOG.md
/Users/mathomp4/Models/GEOSgcm-mepo-newfilesvorigin/GEOSgcm/src/Shared/@MAPL/generic/MAPL_Generic.F90
/Users/mathomp4/Models/GEOSgcm-mepo-newfilesvorigin/GEOSgcm/src/Components/@GEOSgcm_GridComp/README.md
```