### PR TITLE
Add tag push delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [1.47.0] - 2022-11-14
+
+### Added
+
+- Added ability to do `mepo tag push --delete` so you can delete a tag on the remote
+
 ## [1.46.0] - 2022-10-18
 
 ### Added

--- a/mepo.d/cmdline/tag_parser.py
+++ b/mepo.d/cmdline/tag_parser.py
@@ -74,6 +74,10 @@ class MepoTagArgParser(object):
             action = 'store_true',
             help = "Force push (be careful!)")
         push.add_argument(
+            '-d', '--delete',
+            action = 'store_true',
+            help = "Delete (be careful!)")
+        push.add_argument(
             'comp_name',
             metavar = 'comp-name',
             nargs = '*',

--- a/mepo.d/command/tag/push/push.py
+++ b/mepo.d/command/tag/push/push.py
@@ -8,7 +8,7 @@ def run(args):
     comps2tagpush = _get_comps_to_list(args.comp_name, allcomps)
     for comp in comps2tagpush:
         git = GitRepository(comp.remote, comp.local)
-        git.push_tag(args.tag_name,args.force)
+        git.push_tag(args.tag_name,args.force,args.delete)
         print(f'Pushed tag {args.tag_name} to {comp.name}')
 
 def _get_comps_to_list(specified_comps, allcomps):

--- a/mepo.d/repository/git.py
+++ b/mepo.d/repository/git.py
@@ -177,10 +177,12 @@ class GitRepository(object):
         cmd = self.__git + ' tag -d {}'.format(tag_name)
         shellcmd.run(shlex.split(cmd))
 
-    def push_tag(self, tag_name, force):
+    def push_tag(self, tag_name, force, delete):
         cmd = self.__git + ' push'
         if force:
             cmd += ' --force'
+        if delete:
+            cmd += ' --delete'
         cmd += ' origin {}'.format(tag_name)
         shellcmd.run(shlex.split(cmd))
 


### PR DESCRIPTION
This PR adds the ability do a remote tag delete with:
```
mepo tag delete tagname repo1 repo2
mepo tag push --delete tagname repo1 repo2
```
The first deletes locally and the second deletes remotely.
