### PR TITLE
Add new reset command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [1.48.0] - 2022-12-09
+
+### Added
+
+- Added new `reset` command to reset a mepo clone
+
 ## [1.47.0] - 2022-11-14
 
 ### Added

--- a/mepo.d/cmdline/parser.py
+++ b/mepo.d/cmdline/parser.py
@@ -340,7 +340,9 @@ class MepoArgParser(object):
     def __reset(self):
         reset = self.subparsers.add_parser(
             'reset',
-            description = 'Reset the current mepo clone to the original state. Must be run in the root of the mepo clone.',
+            description = 'Reset the current mepo clone to the original state. '
+                          'This will delete all subrepos and does not check for uncommitted changes! '
+                          'Must be run in the root of the mepo clone.',
             aliases=mepoconfig.get_command_alias('reset'))
         reset.add_argument(
             '-f','--force',

--- a/mepo.d/cmdline/parser.py
+++ b/mepo.d/cmdline/parser.py
@@ -36,6 +36,7 @@ class MepoArgParser(object):
         self.__pull()
         self.__pull_all()
         self.__compare()
+        self.__reset()
         self.__whereis()
         self.__stage()
         self.__unstage()
@@ -335,6 +336,24 @@ class MepoArgParser(object):
             '--wrap',
             action = 'store_true',
             help = 'Tells command to ignore terminal size and wrap')
+
+    def __reset(self):
+        reset = self.subparsers.add_parser(
+            'reset',
+            description = 'Reset the current mepo clone to the original state. Must be run in the root of the mepo clone.',
+            aliases=mepoconfig.get_command_alias('reset'))
+        reset.add_argument(
+            '-f','--force',
+            action = 'store_true',
+            help = 'Force action.')
+        reset.add_argument(
+            '--reclone',
+            action = 'store_true',
+            help = 'Reclone repos after reset.')
+        reset.add_argument(
+            '-n','--dry-run',
+            action = 'store_true',
+            help = 'Dry-run only')
 
     def __whereis(self):
         whereis = self.subparsers.add_parser(

--- a/mepo.d/command/reset/reset.py
+++ b/mepo.d/command/reset/reset.py
@@ -12,15 +12,6 @@ from command.clone import clone as mepo_clone
 # of the project.
 
 def run(args):
-    # If a user has called this command without the force flag, we
-    # will ask them to confirm that they want to reset the project
-    if not args.force and not args.dry_run:
-        print(f"Are you sure you want to reset the project? If so, type 'yes' and press enter.", end=' ')
-        answer = input()
-        if answer != "yes":
-            print("Reset cancelled.")
-            return
-
     allcomps = MepoState.read_state()
 
     # Check to see that we are in the root directory of the project
@@ -33,6 +24,15 @@ def run(args):
         raise NotInRootDirError('Error! As a safety precaution, you must be in the root directory of the project to reset')
 
     # If we get this far, then we are in the root directory of the project
+
+    # If a user has called this command without the force flag, we
+    # will ask them to confirm that they want to reset the project
+    if not args.force and not args.dry_run:
+        print(f"Are you sure you want to reset the project? If so, type 'yes' and press enter.", end=' ')
+        answer = input()
+        if answer != "yes":
+            print("Reset cancelled.")
+            return
 
     # First, we need to delete all the subrepos
     # Loop over all the components in reverse (since we are deleting them)

--- a/mepo.d/command/reset/reset.py
+++ b/mepo.d/command/reset/reset.py
@@ -1,0 +1,87 @@
+import os
+import shutil
+
+from state.state import MepoState
+from state.exceptions import NotInRootDirError
+
+from command.clone import clone as mepo_clone
+
+# This command will "reset" the mepo clone. This will delete all
+# the subrepos, remove the .mepo directory, and then re-clone all the
+# subrepos. This is useful if you want to start over with a fresh clone
+# of the project.
+
+def run(args):
+    # If a user has called this command without the force flag, we
+    # will ask them to confirm that they want to reset the project
+    if not args.force and not args.dry_run:
+        print(f"Are you sure you want to reset the project? If so, type 'yes' and press enter.", end=' ')
+        answer = input()
+        if answer != "yes":
+            print("Reset cancelled.")
+            return
+
+    allcomps = MepoState.read_state()
+
+    # Check to see that we are in the root directory of the project
+    ## First get the root directory of the project
+    rootdir = MepoState.get_root_dir()
+    ## Then get the current directory
+    curdir = os.getcwd()
+    ## Then check that they are the same, if they are not, then throw a NotInRootDirError
+    if rootdir != curdir:
+        raise NotInRootDirError('Error! As a safety precaution, you must be in the root directory of the project to reset')
+
+    # If we get this far, then we are in the root directory of the project
+
+    # First, we need to delete all the subrepos
+    # Loop over all the components in reverse (since we are deleting them)
+    for comp in reversed(allcomps):
+        # If the component is the Fixture, then skip it
+        if comp.fixture:
+            continue
+        else:
+            # Get the relative path to the component
+            relpath = _get_relative_path(comp.local)
+            print(f'Removing {relpath}', end='...')
+            # Remove the component if not dry run
+            if not args.dry_run:
+                shutil.rmtree(relpath)
+                print('done.')
+            else:
+                print(f'dry-run only. Not removing {relpath}')
+
+    # Next, we need to remove the .mepo directory
+    print(f'Removing .mepo', end='...')
+    if not args.dry_run:
+        shutil.rmtree('.mepo')
+        print('done.')
+    else:
+        print(f'dry-run only. Not removing .mepo')
+
+    # If they pass in the --reclone flag, then we will re-clone all the subrepos
+    if args.reclone:
+
+        # mepo_clone requires args which is an Argparse Namespace object
+        # We will create a new Namespace object with the correct arguments
+        # for mepo_clone
+        clone_args = type('Namespace', (object,), {'repo_url': None, 'directory': None, 'branch': None, 'config': None, 'allrepos': False, 'style': None})
+        if not args.dry_run:
+            print('Re-cloning all subrepos')
+            mepo_clone.run(clone_args)
+            print('Recloning done.')
+        else:
+            print(f'Dry-run only. Not re-cloning all subrepos')
+
+def _get_relative_path(local_path):
+    """
+    Get the relative path when given a local path.
+
+    local_path: The path to a subrepo as known by mepo (relative to the .mepo directory)
+    """
+
+    # This creates a full path on the disk from the root of mepo and the local_path
+    full_local_path=os.path.join(MepoState.get_root_dir(),local_path)
+
+    # We return the path relative to where we currently are
+    return os.path.relpath(full_local_path, os.getcwd())

--- a/mepo.d/state/exceptions.py
+++ b/mepo.d/state/exceptions.py
@@ -17,3 +17,7 @@ class ConfigFileNotFoundError(FileNotFoundError):
 class SuffixNotRecognizedError(RuntimeError):
     """Raised when the config suffix is not recognized"""
     pass
+
+class NotInRootDirError(SystemExit):
+    """Raised when a command is run not in the root directory"""
+    pass


### PR DESCRIPTION
Closes #244 

This PR adds a new `mepo reset` command:
```
❯ mepo reset -h
usage: mepo reset [-h] [-f] [--reclone] [-n]

Reset the current mepo clone to the original state.This will delete all subrepos and does not check for uncommitted changes! Must be run in the root of
the mepo clone.

options:
  -h, --help     show this help message and exit
  -f, --force    Force action.
  --reclone      Reclone repos after reset.
  -n, --dry-run  Dry-run only
```

By default, it will not re-clone a repo and will require a user to answer another question to run (without force flag):
```
❯ mepo clone
Initializing mepo using components.yaml
ESMA_env   | (t) v4.8.0
ESMA_cmake | (t) v3.21.0
ecbuild    | (t) geos/v1.3.0
❯ mepo reset
Are you sure you want to reset the project? If so, type 'yes' and press enter. yes
Removing ESMA_cmake/ecbuild...done.
Removing ESMA_cmake...done.
Removing ESMA_env...done.
Removing .mepo...done.
❯ ls -1 ESMA_env | head -1
ls: ESMA_env: No such file or directory
```

You can do a reclone with `--reclone`:
```
❯ mepo clone
Initializing mepo using components.yaml
ESMA_env   | (t) v4.8.0
ESMA_cmake | (t) v3.21.0
ecbuild    | (t) geos/v1.3.0
❯ mepo reset --reclone -f
Removing ESMA_cmake/ecbuild...done.
Removing ESMA_cmake...done.
Removing ESMA_env...done.
Removing .mepo...done.
Re-cloning all subrepos
Initializing mepo using components.yaml
ESMA_env   | (t) v4.8.0
ESMA_cmake | (t) v3.21.0
ecbuild    | (t) geos/v1.3.0
Recloning done.
❯ ls -1 ESMA_env | head -1
BASEDIR.rc.in
```

Note we also require the user to be in the root of a fixture:
```
❯ mepo clone
Initializing mepo using components.yaml
ESMA_env   | (t) v4.8.0
ESMA_cmake | (t) v3.21.0
ecbuild    | (t) geos/v1.3.0
❯ cd ESMA_cmake/ecbuild
❯ mepo reset
Error! As a safety precaution, you must be in the root directory of the project to reset
```