### PR TITLE
Compare headers based on changed branch length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- When running `compare`, use columns whose size is based on the longest branch name of a repo that has changed (unless `--all` is
+  passed in)
+
 ### Removed
 
 ## [1.48.0] - 2022-12-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- When running `compare`, use columns whose size is based on the longest branch name of a repo that has changed (unless `--all` is
-  passed in)
-
 ### Removed
+
+## [1.49.0] - 2023-01-25
+
+### Changed
+
+- When running `compare` in default mode, size columns based on the longest branch name of a repo that has changed. This prevents
+  odd column widths based on long branch names in repos that haven't changed
 
 ## [1.48.0] - 2022-12-09
 

--- a/mepo.d/command/compare/compare.py
+++ b/mepo.d/command/compare/compare.py
@@ -61,6 +61,8 @@ def calculate_header_lengths(allcomps, all_repos=False):
             names.append(comp.name)
             versions.append(version_to_string(comp.version,git))
     max_namelen = len(max(names, key=len))
+    # Note: max_namelen could be 3 characters but we want at least 4 for "Repo"
+    max_namelen = max(max_namelen, 4)
     max_origlen = len(max(versions, key=len))
     return max_namelen, max_origlen
 

--- a/mepo.d/utest/output/compare_brief_output.txt
+++ b/mepo.d/utest/output/compare_brief_output.txt
@@ -1,5 +1,5 @@
-Repo                   | Original                         | Current
----------------------- | -------------------------------- | -------
-env                    | (t) v3.13.0 (DH)                 | (b) main
-cmake                  | (t) v3.12.0 (DH)                 | (b) develop
-fvdycore               | (t) geos/v1.3.0 (DH)             | (b) geos/develop
+Repo     | Original             | Current
+-------- | -------------------- | -------
+env      | (t) v4.8.0 (DH)      | (b) main
+cmake    | (t) v3.21.0 (DH)     | (b) develop
+fvdycore | (t) geos/v1.5.0 (DH) | (b) geos/develop

--- a/mepo.d/utest/output/compare_full_output.txt
+++ b/mepo.d/utest/output/compare_full_output.txt
@@ -1,11 +1,11 @@
 Repo                   | Original                         | Current
 ---------------------- | -------------------------------- | -------
-GEOSfvdycore           | (t) v1.5.0 (DH)                  | (t) v1.5.0 (DH)
-env                    | (t) v3.13.0 (DH)                 | (b) main
-cmake                  | (t) v3.12.0 (DH)                 | (b) develop
-ecbuild                | (t) geos/v1.2.0 (DH)             | (t) geos/v1.2.0 (DH)
-GMAO_Shared            | (t) v1.5.3 (DH)                  | (t) v1.5.3 (DH)
-MAPL                   | (t) v2.19.0 (DH)                 | (t) v2.19.0 (DH)
+GEOSfvdycore           | (t) v1.13.0 (DH)                 | (t) v1.13.0 (DH)
+env                    | (t) v4.8.0 (DH)                  | (b) main
+cmake                  | (t) v3.21.0 (DH)                 | (b) develop
+ecbuild                | (t) geos/v1.3.0 (DH)             | (t) geos/v1.3.0 (DH)
+GMAO_Shared            | (t) v1.6.3 (DH)                  | (t) v1.6.3 (DH)
+MAPL                   | (t) v2.33.0 (DH)                 | (t) v2.33.0 (DH)
 FMS                    | (t) geos/2019.01.02+noaff.8 (DH) | (t) geos/2019.01.02+noaff.8 (DH)
-FVdycoreCubed_GridComp | (t) v1.6.0 (DH)                  | (t) v1.6.0 (DH)
-fvdycore               | (t) geos/v1.3.0 (DH)             | (b) geos/develop
+FVdycoreCubed_GridComp | (t) v1.12.1 (DH)                 | (t) v1.12.1 (DH)
+fvdycore               | (t) geos/v1.5.0 (DH)             | (b) geos/develop

--- a/mepo.d/utest/output/status_output.txt
+++ b/mepo.d/utest/output/status_output.txt
@@ -1,10 +1,10 @@
 Checking status...
-GEOSfvdycore           | (t) v1.5.0 (DH)
+GEOSfvdycore           | (t) v1.13.0 (DH)
 env                    | (b) main
 cmake                  | (b) develop
-ecbuild                | (t) geos/v1.2.0 (DH)
-GMAO_Shared            | (t) v1.5.3 (DH)
-MAPL                   | (t) v2.19.0 (DH)
+ecbuild                | (t) geos/v1.3.0 (DH)
+GMAO_Shared            | (t) v1.6.3 (DH)
+MAPL                   | (t) v2.33.0 (DH)
 FMS                    | (t) geos/2019.01.02+noaff.8 (DH)
-FVdycoreCubed_GridComp | (t) v1.6.0 (DH)
+FVdycoreCubed_GridComp | (t) v1.12.1 (DH)
 fvdycore               | (b) geos/develop

--- a/mepo.d/utest/test_mepo_commands.py
+++ b/mepo.d/utest/test_mepo_commands.py
@@ -38,7 +38,7 @@ class TestMepoCommands(unittest.TestCase):
         cls.input_dir = os.path.join(THIS_DIR, 'input')
         cls.output_dir = os.path.join(THIS_DIR, 'output')
         cls.fixture = 'GEOSfvdycore'
-        cls.tag = 'v1.5.0'
+        cls.tag = 'v1.13.0'
         cls.tmpdir = os.path.join(THIS_DIR, 'tmp')
         cls.fixture_dir = os.path.join(cls.tmpdir, cls.fixture)
         if os.path.isdir(cls.fixture_dir):


### PR DESCRIPTION
As discovered by @pchakraborty, if an original branch name is very long, this can cause odd output of `mepo compare` on narrow (relative to the branch name) terminals. 

With this fix, `mepo compare` will use only the repos that change to figure out how wide to make the output rather than *all* the branches on all the repos.

Of course, if you do `mepo compare --all`, it will base the output on all the repos.