### PR TITLE
Add `--hashes` reading HEAD to get the current hash

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,12 +1,12 @@
 {
-   "license": "other-open", 
-   "upload_type": "software", 
+   "license": "other-open",
+   "upload_type": "software",
    "creators": [
       {
          "name": "Thompson, Matthew",
          "affiliation": "GMAO SSAI",
          "orcid": "0000-0001-6222-6863"
-      }, 
+      },
       {
          "name": "Chakraborty, Purnendu"
       },
@@ -14,11 +14,16 @@
          "name": "Jamieson, William",
          "affiliation": "GMAO SSAI",
          "orcid": "0000-0001-5976-4492"
-      }, 
+      },
       {
          "name": "Clune, Tom",
          "affiliation": "NASA",
          "orcid": "0000-0003-3320-0204"
+      },
+      {
+         "name": "Deconinck, Florian",
+         "affiliation": "NASA SSAI",
+         "orcid": "0000-0002-0925-917X"
       }
    ],
    "contributors": [
@@ -27,7 +32,7 @@
          "affiliation": "GMAO SSAI",
          "orcid": "0000-0001-6222-6863",
          "type": "ContactPerson"
-      }, 
+      },
       {
          "name": "Clune, Tom",
          "affiliation": "NASA",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+Command `status` has now a `--hashes` option that list current HEAD hash for each component.
+
 ### Changed
 
 ### Removed
@@ -107,9 +109,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - When running `mepo compare` and `mepo status`, detatched branches will also display the commit id:
+
   ```
   GEOSgcm_GridComp       | (b) feature/aogcm (DH, 0793f7b2)
   ```
+
 - GitHub Actions updates
   - Uses `pypy-3.8` specifically
   - Have `pip` install from `requirements.txt`
@@ -135,11 +139,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* Allows `mepo checkout -b <branch>` to run on all repos rather than requiring one to be specified
+- Allows `mepo checkout -b <branch>` to run on all repos rather than requiring one to be specified
 
 ### Fixed
 
-* Fixes a bug in handling paths with spaces in folder names
+- Fixes a bug in handling paths with spaces in folder names
 
 ## [1.36.1] - 2021-08-19
 
@@ -392,11 +396,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-* Update the CI to use a matrix on Linux and macOS of python3.x and pypy3
+- Update the CI to use a matrix on Linux and macOS of python3.x and pypy3
 
 ### Fixed
 
-* Fix the unit tests
+- Fix the unit tests
 
 ## [1.11.0] - 2020-05-28
 
@@ -432,10 +436,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* Add `--name-only` to `mepo diff`
-* Add colors to `mepo status` for non-original branches
-* Make `checkout-if-exists` more verbose
-* Make `mepo commit` act more like `git commit`
+- Add `--name-only` to `mepo diff`
+- Add colors to `mepo status` for non-original branches
+- Make `checkout-if-exists` more verbose
+- Make `mepo commit` act more like `git commit`
 
 ## [1.6.0] - 2020-02-19
 

--- a/mepo.d/cmdline/parser.py
+++ b/mepo.d/cmdline/parser.py
@@ -124,6 +124,10 @@ class MepoArgParser(object):
             '--nocolor',
             action = 'store_true',
             help = 'Tells status to not display colors.')
+        status.add_argument(
+            '--hashes',
+            action = 'store_true',
+            help = 'Print the exact hash of the HEAD.')
 
     def __restore_state(self):
         restore_state = self.subparsers.add_parser(


### PR DESCRIPTION
This is useful for working repository when there's a lot of "develop" branch going on and that you don't necessarily want to tag the root component.
The hash is read on demand and not stored.