### PR TITLE
Add ability to ignore submodules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added new `ignore_submodules` field in `components.yaml` to allow ignoring submodules in a repo. Currently used for `status` and
+  `diff` commands.
+
 ### Changed
 
 ### Removed

--- a/mepo.d/command/diff/diff.py
+++ b/mepo.d/command/diff/diff.py
@@ -29,7 +29,7 @@ def _get_comps_to_diff(specified_comps, allcomps):
 
 def check_component_diff(comp, args):
     git = GitRepository(comp.remote, comp.local)
-    return git.run_diff(args)
+    return git.run_diff(args, comp.ignore_submodules)
 
 def print_diff(comp, args, output):
     columns, lines = get_terminal_size(fallback=(80,20))

--- a/mepo.d/command/status/status.py
+++ b/mepo.d/command/status/status.py
@@ -18,7 +18,7 @@ def run(args):
     result = pool.starmap(check_component_status, [(comp, args.ignore_permissions) for comp in allcomps])
     print_status(allcomps, result, args.nocolor, args.hashes)
 
-def check_component_status(comp, ignore):
+def check_component_status(comp, ignore_permissions):
     git = GitRepository(comp.remote, comp.local)
 
     # version_to_string can strip off 'origin/' for display purposes
@@ -32,7 +32,7 @@ def check_component_status(comp, ignore):
     # This command is to try and work with git tag oddities
     curr_ver = sanitize_version_string(orig_ver,curr_ver,git)
 
-    return (curr_ver, internal_state_branch_name, git.check_status(ignore))
+    return (curr_ver, internal_state_branch_name, git.check_status(ignore_permissions,comp.ignore_submodules))
 
 def print_status(allcomps, result, nocolor=False, hashes=False):
     orig_width = len(max([comp.name for comp in allcomps], key=len))

--- a/mepo.d/repository/git.py
+++ b/mepo.d/repository/git.py
@@ -122,7 +122,7 @@ class GitRepository(object):
         output = shellcmd.run(shlex.split(cmd),output=True)
         return output.rstrip()
 
-    def run_diff(self, args=None):
+    def run_diff(self, args=None, ignore_submodules=False):
         cmd = 'git -C {}'.format(self.__full_local_path)
         if args.ignore_permissions:
             cmd += ' -c core.fileMode=false'
@@ -135,6 +135,8 @@ class GitRepository(object):
             cmd += ' --staged'
         if args.ignore_space_change:
             cmd += ' --ignore-space-change'
+        if ignore_submodules:
+            cmd += ' --ignore-submodules=all'
         output = shellcmd.run(shlex.split(cmd),output=True)
         return output.rstrip()
 
@@ -199,11 +201,13 @@ class GitRepository(object):
             ref_type = "Branch"
         return status, ref_type
 
-    def check_status(self, ignore_permissions=False):
+    def check_status(self, ignore_permissions=False, ignore_submodules=False):
         cmd = 'git -C {}'.format(self.__full_local_path)
         if ignore_permissions:
             cmd += ' -c core.fileMode=false'
         cmd += ' status --porcelain=v2'
+        if ignore_submodules:
+            cmd += ' --ignore-submodules=all'
         output = shellcmd.run(shlex.split(cmd), output=True)
         if output.strip():
             output_list = output.splitlines()

--- a/mepo.d/state/component.py
+++ b/mepo.d/state/component.py
@@ -11,7 +11,7 @@ original_final_node_list = []
 
 class MepoComponent(object):
 
-    __slots__ = ['name', 'local', 'remote', 'version', 'sparse', 'develop', 'recurse_submodules', 'fixture']
+    __slots__ = ['name', 'local', 'remote', 'version', 'sparse', 'develop', 'recurse_submodules', 'fixture', 'ignore_submodules']
 
     def __init__(self):
         self.name = None
@@ -22,10 +22,11 @@ class MepoComponent(object):
         self.develop = None
         self.recurse_submodules = None
         self.fixture = None
+        self.ignore_submodules = None
 
     def __repr__(self):
-        return '{} - local: {}, remote: {}, version: {}, sparse: {}, develop: {}, recurse_submodules: {}, fixture: {}'.format(
-            self.name, self.local, self.remote, self.version, self.sparse, self.develop, self.recurse_submodules, self.fixture)
+        return '{} - local: {}, remote: {}, version: {}, sparse: {}, develop: {}, recurse_submodules: {}, fixture: {}, ignore_submodules: {}'.format(
+            self.name, self.local, self.remote, self.version, self.sparse, self.develop, self.recurse_submodules, self.fixture, self.ignore_submodules)
 
     def __set_original_version(self, comp_details):
         if self.fixture:
@@ -71,7 +72,7 @@ class MepoComponent(object):
         self.version = MepoVersion(ver_name, ver_type, is_detached)
 
     def __validate_fixture(self, comp_details):
-        unallowed_keys = ['remote', 'local', 'branch', 'hash', 'tag', 'sparse', 'recurse_submodules']
+        unallowed_keys = ['remote', 'local', 'branch', 'hash', 'tag', 'sparse', 'recurse_submodules', 'ignore_submodules']
         if any([comp_details.get(key) for key in unallowed_keys]):
             raise Exception("Fixtures are only allowed fixture and develop")
 
@@ -135,6 +136,7 @@ class MepoComponent(object):
         self.sparse = comp_details.get('sparse', None) # sparse is optional
         self.develop = comp_details.get('develop', None) # develop is optional
         self.recurse_submodules = comp_details.get('recurse_submodules', None) # recurse_submodules is optional
+        self.ignore_submodules = comp_details.get('ignore_submodules', None) # ignore_submodules is optional
         self.__set_original_version(comp_details)
         return self
 
@@ -163,6 +165,8 @@ class MepoComponent(object):
                 details['develop'] = self.develop
             if self.recurse_submodules:
                 details['recurse_submodules'] = self.recurse_submodules
+            if self.ignore_submodules:
+                details['ignore_submodules'] = self.ignore_submodules
         return {self.name: details}
 
 def get_current_remote_url():


### PR DESCRIPTION
As detailed in #257, a mepo oddity occurs in GEOSgcm because of how CICE and icepack are handled. 

Technically, icepack is a submodule of CICE in the repo (see https://github.com/GEOS-ESM/CICE) and git sees it as that. However, currently GEOS handles icepack as a separate repo (most likely for ease of development) but git doesn't really know this. So when you go to CICE in GEOS in a fresh clone you see:

```
$ git status
HEAD detached at geos/v0.0.2
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   icepack (new commits)

Submodules changed but not updated:

* icepack 81a7628...8d80ff5 (1):
  > Merge pull request #1 from GEOS-ESM/bugfix/zhaobin74/recompute-enthalpy

no changes added to commit (use "git add" and/or "git commit -a")
```

and since `mepo status` just sort of "echoes" status output with `mepo status` we see:
```
cice6                  | (t) geos/v0.0.2 (DH)
   | icepack: modified, not staged
```
So git says "something changed" but we want to ignore that in this case.

Thus, this PR adds a new field to `components.yaml`, `ignore_submodules`:
```yaml
cice6:
  local: ./src/Components/@GEOSgcm_GridComp/GEOSogcm_GridComp/GEOSseaice_GridComp/CICE_GEOSPlug/@cice6
  remote: ../CICE.git
  tag: geos/v0.0.2
  develop: geos/develop
  ignore_submodules: true
```
If this is true, then we add `--ignore-submodules=all` to underlying git calls when we run `mepo diff` and `mepo status`