### PR TITLE
Fixes for older mepo clones in re ignore_submodules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [1.51.1] - 2023-08-25
+
+### Fixed
+
+- Fixes to allow mepo to work on older mepo clones that don't have ignore_submodules in their state
+
 ## [1.51.0] - 2023-08-25
 
 ### Added

--- a/mepo.d/command/status/status.py
+++ b/mepo.d/command/status/status.py
@@ -21,6 +21,13 @@ def run(args):
 def check_component_status(comp, ignore_permissions):
     git = GitRepository(comp.remote, comp.local)
 
+    # Older mepo clones will not have ignore_submodules in comp, so
+    # we need to handle this gracefully
+    try:
+        _ignore_submodules = comp.ignore_submodules
+    except AttributeError:
+        _ignore_submodules = None
+
     # version_to_string can strip off 'origin/' for display purposes
     # so we save the "internal" name for comparison
     internal_state_branch_name = git.get_version()[0]
@@ -32,7 +39,7 @@ def check_component_status(comp, ignore_permissions):
     # This command is to try and work with git tag oddities
     curr_ver = sanitize_version_string(orig_ver,curr_ver,git)
 
-    return (curr_ver, internal_state_branch_name, git.check_status(ignore_permissions,comp.ignore_submodules))
+    return (curr_ver, internal_state_branch_name, git.check_status(ignore_permissions,_ignore_submodules))
 
 def print_status(allcomps, result, nocolor=False, hashes=False):
     orig_width = len(max([comp.name for comp in allcomps], key=len))

--- a/mepo.d/state/component.py
+++ b/mepo.d/state/component.py
@@ -25,8 +25,15 @@ class MepoComponent(object):
         self.ignore_submodules = None
 
     def __repr__(self):
+        # Older mepo clones will not have ignore_submodules in comp, so
+        # we need to handle this gracefully
+        try:
+            _ignore_submodules = self.ignore_submodules
+        except AttributeError:
+            _ignore_submodules = None
+
         return '{} - local: {}, remote: {}, version: {}, sparse: {}, develop: {}, recurse_submodules: {}, fixture: {}, ignore_submodules: {}'.format(
-            self.name, self.local, self.remote, self.version, self.sparse, self.develop, self.recurse_submodules, self.fixture, self.ignore_submodules)
+            self.name, self.local, self.remote, self.version, self.sparse, self.develop, self.recurse_submodules, self.fixture, _ignore_submodules)
 
     def __set_original_version(self, comp_details):
         if self.fixture:


### PR DESCRIPTION
It turns out changes from #260 (aka mepo v1.51.0) don't work with older mepo clones that might not have the ignore_submodules in their state. `AttributeError` galore. This fixes that.