### PR TITLE
Add support for partial clones

### DIFF
--- a/.github/workflows/mepo.yaml
+++ b/.github/workflows/mepo.yaml
@@ -8,14 +8,14 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ['3.9', '3.10', '3.11', 'pypy-3.9']
+        python-version: ['3.9', '3.10', '3.11', '3.12', 'pypy-3.9', 'pypy-3.10']
 
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the clone will not download blobs by using `--filter=blob:none`. If you set `--partial=treeless` then the clone will not download
   trees by using `--filter=tree:0`. The `blobless` option is useful for large repos that have a lot of binary files that you don't
   need. The `treeless` option is even more aggressive and *SHOULD NOT* be used unless you know what you are doing.
+- Add a new section for `.mepoconfig` to allow users to set `--partial` as a default for `mepo clone`.
 
 ## [1.51.1] - 2023-08-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [1.52.0] - 2024-01-10
+
+### Added
+
+- Added new `--partial` option to `mepo clone` with two settings: `blobless` and `treeless`. If you set, `--partial=blobless` then
+  the clone will not download blobs by using `--filter=blob:none`. If you set `--partial=treeless` then the clone will not download
+  trees by using `--filter=tree:0`. The `blobless` option is useful for large repos that have a lot of binary files that you don't
+  need. The `treeless` option is even more aggressive and *SHOULD NOT* be used unless you know what you are doing.
+
 ## [1.51.1] - 2023-08-25
 
 ### Fixed

--- a/etc/mepoconfig-example
+++ b/etc/mepoconfig-example
@@ -2,7 +2,7 @@
 #
 # .mepoconfig is a config file a la gitconfig with sections and options.
 #
-# Currently, .mepoconfig files recognize two sections: [init] and [alias]
+# Currently, .mepoconfig files recognize three sections: [init], [alias], and [clone].
 #
 # =======================================================================
 #
@@ -24,6 +24,10 @@
 #
 #     mepo clone --style postfix
 #
+#   You set these options by running:
+#
+#     mepo config set init.style <value>
+#
 # =======================================================================
 #
 # [alias] Section
@@ -40,3 +44,40 @@
 #         you can only alias mepo primary commands and not "subcommands" or
 #         "options". So you can have an alias for "commit" and for "branch",
 #         but you can't do an option for "commit -m" or "branch create".
+#
+#   You can set an alias by running:
+#
+#     mepo config set alias.<alias> <command>
+#
+# =======================================================================
+#
+# [clone] Section
+#
+#   The clone section currently recognizes one option, partial.
+#   This has two allowed values: blobless and treeless
+#
+#   So if you have:
+#
+#     [clone]
+#     partial = blobless
+#
+#   This is equivalent to doing:
+#
+#     mepo clone --partial=blobless
+#
+#   which corresponds to the git clone option --filter=blob:none
+#
+#   and similarly for treeless:
+#
+#     [clone]
+#     partial = treeless
+#
+#   is equivalent to doing:
+#
+#     mepo clone --partial=treeless
+#
+#   which corresponds to the git clone option --filter=tree:0
+#
+#   You set these options by running:
+#
+#     mepo config set clone.partial <value>

--- a/mepo.d/cmdline/parser.py
+++ b/mepo.d/cmdline/parser.py
@@ -104,6 +104,13 @@ class MepoArgParser(object):
             '--allrepos',
             action = 'store_true',
             help = 'Must be passed with -b/--branch. When set, it not only checkouts out the branch/tag for the fixture, but for all the subrepositories as well.')
+        clone.add_argument(
+            '--partial',
+            metavar = 'partial-type',
+            nargs = '?',
+            default = None,
+            choices = ['blobless','treeless'],
+            help = 'Style of partial clone, default: None, allowed options: %(choices)s. Note that blobless means cloning with --filter=blob:none and treeless means cloning with --filter=tree:0. NOTE: We do *not* recommend using "treeless" as it is very aggressive and will cause problems with many git commands.')
 
     def __list(self):
         listcomps = self.subparsers.add_parser(

--- a/mepo.d/command/clone/clone.py
+++ b/mepo.d/command/clone/clone.py
@@ -31,9 +31,6 @@ def run(args):
     else:
         partial = None
 
-    blobless = partial == 'blobless'
-    treeless = partial == 'treeless'
-
     # If you pass in a config, with clone, it could be outside the repo.
     # So use the full path
     passed_in_config = False
@@ -50,7 +47,7 @@ def run(args):
         last_url_node = p.path.rsplit('/')[-1]
         url_suffix = pathlib.Path(last_url_node).suffix
         if args.directory:
-            local_clone(args.repo_url,args.branch,args.directory,blobless,treeless)
+            local_clone(args.repo_url,args.branch,args.directory,partial)
             os.chdir(args.directory)
         else:
             if url_suffix == '.git':
@@ -58,7 +55,7 @@ def run(args):
             else:
                 git_url_directory = last_url_node
 
-            local_clone(args.repo_url,args.branch,git_url_directory,blobless,treeless)
+            local_clone(args.repo_url,args.branch,git_url_directory,partial)
             os.chdir(git_url_directory)
 
     # Copy the new file into the repo only if we pass it in
@@ -87,7 +84,7 @@ def run(args):
             recurse = comp.recurse_submodules
             # We need the type to handle hashes in components.yaml
             type = comp.version.type
-            git.clone(version,recurse,type,comp.name,blobless,treeless)
+            git.clone(version,recurse,type,comp.name,partial)
             if comp.sparse:
                 git.sparsify(comp.sparse)
             print_clone_info(comp, max_namelen)
@@ -105,11 +102,11 @@ def print_clone_info(comp, name_width):
     ver_name_type = '({}) {}'.format(comp.version.type, comp.version.name)
     print('{:<{width}} | {:<s}'.format(comp.name, ver_name_type, width = name_width))
 
-def local_clone(url,branch=None,directory=None,blobless=False,treeless=False):
+def local_clone(url,branch=None,directory=None,partial=None):
     cmd1 = 'git clone '
-    if blobless:
+    if partial == 'blobless':
         cmd1 += '--filter=blob:none '
-    if treeless:
+    elif partial == 'treeless':
         cmd1 += '--filter=tree:0 '
     if branch:
         cmd1 += '--branch {} '.format(branch)

--- a/mepo.d/repository/git.py
+++ b/mepo.d/repository/git.py
@@ -39,13 +39,12 @@ class GitRepository(object):
     def get_remote_url(self):
         return self.__remote
 
-    def clone(self, version, recurse, type, comp_name, blobless=False, treeless=False):
+    def clone(self, version, recurse, type, comp_name, partial=None):
         cmd1 = 'git clone '
 
-        if blobless:
+        if partial == 'blobless':
             cmd1 += '--filter=blob:none '
-
-        if treeless:
+        elif partial == 'treeless':
             cmd1 += '--filter=tree:0 '
 
         if recurse:

--- a/mepo.d/repository/git.py
+++ b/mepo.d/repository/git.py
@@ -39,8 +39,15 @@ class GitRepository(object):
     def get_remote_url(self):
         return self.__remote
 
-    def clone(self, version, recurse, type, comp_name):
+    def clone(self, version, recurse, type, comp_name, blobless=False, treeless=False):
         cmd1 = 'git clone '
+
+        if blobless:
+            cmd1 += '--filter=blob:none '
+
+        if treeless:
+            cmd1 += '--filter=tree:0 '
+
         if recurse:
             cmd1 += '--recurse-submodules '
 

--- a/mepo.d/utest/test_mepo_commands.py
+++ b/mepo.d/utest/test_mepo_commands.py
@@ -53,6 +53,7 @@ class TestMepoCommands(unittest.TestCase):
         args.repo_url = None
         args.branch = None
         args.directory = None
+        args.partial = 'blobless'
         mepo_clone.run(args)
         # In order to better test compare, we need to do *something*
         args.comp_name = ['env','cmake','fvdycore']


### PR DESCRIPTION
This PR adds support for partial clones with `mepo clone`. A new option `--partial` has two settings:

* `blobless`: performs a blobless clone via `git clone --filter=blob:none`
* `treeless`: performs a treeless clone via `git clone --filter=tree:0`

The motivation for this is that it has been noticed that clones of GEOS (mainly MAPL) are often extremely slow. For example:
```
❯ time git clone git@github.com:GEOS-ESM/MAPL.git MAPL-normal
Cloning into 'MAPL-normal'...
remote: Enumerating objects: 704212, done.
remote: Counting objects: 100% (271489/271489), done.
remote: Compressing objects: 100% (6882/6882), done.
remote: Total 704212 (delta 269709), reused 266119 (delta 264584), pack-reused 432723
Receiving objects: 100% (704212/704212), 997.08 MiB | 2.59 MiB/s, done.
Resolving deltas: 100% (694344/694344), done.
noglob git clone git@github.com:GEOS-ESM/MAPL.git MAPL-normal  95.46s user 13.88s system 24% cpu 7:17.37 total
```

This took over 7 minutes to clone!

However, git supports partial clones as detailed in [this GitHub Blog post](https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/). Now, of the two, blobless clones are fairly safe and give you faster initial clone speed at the cost of slower operations after that. As a test:

```
❯ time git clone --filter=blob:none git@github.com:GEOS-ESM/MAPL.git MAPL-blobless-from-git
Cloning into 'MAPL-blobless-from-git'...
remote: Enumerating objects: 21299, done.
remote: Counting objects: 100% (3171/3171), done.
remote: Compressing objects: 100% (1324/1324), done.
remote: Total 21299 (delta 1972), reused 2989 (delta 1829), pack-reused 18128
Receiving objects: 100% (21299/21299), 20.80 MiB | 2.99 MiB/s, done.
Resolving deltas: 100% (13343/13343), done.
remote: Enumerating objects: 942, done.
remote: Counting objects: 100% (552/552), done.
remote: Compressing objects: 100% (500/500), done.
remote: Total 942 (delta 112), reused 126 (delta 50), pack-reused 390
Receiving objects: 100% (942/942), 1.85 MiB | 136.00 KiB/s, done.
Resolving deltas: 100% (249/249), done.
Updating files: 100% (1064/1064), done.
noglob git clone --filter=blob:none git@github.com:GEOS-ESM/MAPL.git   1.38s user 0.54s system 6% cpu 27.609 total
```

28 seconds!

Treeless clones are usually faster than blobless as you aren't just filtering out blobs but whole trees. But per the blog:

> We **strongly recommend** that developers do not use treeless clones for their daily work. Treeless clones are really only helpful for automated builds when you want to quickly clone, compile a project, then throw away the repository. In environments like GitHub Actions using public runners, you want to minimize your clone time so you can spend your machine time actually building your software! Treeless clones might be an excellent option for those environments.

As there are possible scenarios with CI that this could be useful for, the option is added. As for speed:

```
❯ time git clone --filter=tree:0 git@github.com:GEOS-ESM/MAPL.git MAPL-treeless
Cloning into 'MAPL-treeless'...
remote: Enumerating objects: 6875, done.
remote: Counting objects: 100% (843/843), done.
remote: Compressing objects: 100% (730/730), done.
remote: Total 6875 (delta 124), reused 805 (delta 113), pack-reused 6032
Receiving objects: 100% (6875/6875), 2.24 MiB | 277.00 KiB/s, done.
Resolving deltas: 100% (757/757), done.
remote: Enumerating objects: 106, done.
remote: Counting objects: 100% (70/70), done.
remote: Compressing objects: 100% (66/66), done.
remote: Total 106 (delta 1), reused 19 (delta 0), pack-reused 36
Receiving objects: 100% (106/106), 37.34 KiB | 538.00 KiB/s, done.
Resolving deltas: 100% (3/3), done.
remote: Enumerating objects: 942, done.
remote: Counting objects: 100% (552/552), done.
remote: Compressing objects: 100% (500/500), done.
remote: Total 942 (delta 112), reused 126 (delta 50), pack-reused 390
Receiving objects: 100% (942/942), 1.85 MiB | 2.09 MiB/s, done.
Resolving deltas: 100% (249/249), done.
Updating files: 100% (1064/1064), done.
noglob git clone --filter=tree:0 git@github.com:GEOS-ESM/MAPL.git   0.45s user 0.25s system 4% cpu 15.950 total
```

16 seconds!

Along with this option, we also add a new `.mepoconfig` setting where one can add:
```config
[clone]
partial = blobless
```
and blobless clones will be the default.