### PR TITLE
Protect submodule repos from treeless, add off option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added new `--partial` option to `mepo clone` with two settings: `blobless` and `treeless`. If you set, `--partial=blobless` then
+- Added new `--partial` option to `mepo clone` with two settings: `off`, `blobless`, and `treeless`. If you set, `--partial=blobless` then
   the clone will not download blobs by using `--filter=blob:none`. If you set `--partial=treeless` then the clone will not download
   trees by using `--filter=tree:0`. The `blobless` option is useful for large repos that have a lot of binary files that you don't
-  need. The `treeless` option is even more aggressive and *SHOULD NOT* be used unless you know what you are doing.
+  need. The `treeless` option is even more aggressive and *SHOULD NOT* be used unless you know what you are doing. The
+  `--partial=off` option allows a user to override the default behavior of `--partial` in `.mepoconfig` and turn it off for a
+  run of `mepo clone`.
 - Add a new section for `.mepoconfig` to allow users to set `--partial` as a default for `mepo clone`.
 
 ## [1.51.1] - 2023-08-25

--- a/mepo.d/cmdline/parser.py
+++ b/mepo.d/cmdline/parser.py
@@ -109,8 +109,8 @@ class MepoArgParser(object):
             metavar = 'partial-type',
             nargs = '?',
             default = None,
-            choices = ['blobless','treeless'],
-            help = 'Style of partial clone, default: None, allowed options: %(choices)s. Note that blobless means cloning with --filter=blob:none and treeless means cloning with --filter=tree:0. NOTE: We do *not* recommend using "treeless" as it is very aggressive and will cause problems with many git commands.')
+            choices = ['off','blobless','treeless'],
+            help = 'Style of partial clone, default: None, allowed options: %(choices)s. Off means a "normal" full git clone, blobless means cloning with "--filter=blob:none" and treeless means cloning with "--filter=tree:0". NOTE: We do *not* recommend using "treeless" as it is very aggressive and will cause problems with many git commands.')
 
     def __list(self):
         listcomps = self.subparsers.add_parser(

--- a/mepo.d/command/clone/clone.py
+++ b/mepo.d/command/clone/clone.py
@@ -93,8 +93,6 @@ def run(args):
 
             _partial = None if partial == 'treeless' and recurse else partial
 
-            print(f'Cloning {comp.name} {version}. Recurse: {recurse}. Partial: {_partial}')
-
             # We need the type to handle hashes in components.yaml
             type = comp.version.type
             git.clone(version,recurse,type,comp.name,_partial)

--- a/mepo.d/command/clone/clone.py
+++ b/mepo.d/command/clone/clone.py
@@ -20,7 +20,10 @@ def run(args):
 
     # We can get the blobless and treeless options from the config or the args
     if args.partial:
-        partial = args.partial
+        # We need to set partial to None if it's off, otherwise we use the
+        # string. This is safe because argparse only allows for 'off',
+        # 'blobless', or 'treeless'
+        partial = None if args.partial == 'off' else args.partial
     elif mepoconfig.has_option('clone','partial'):
         allowed = ['blobless','treeless']
         partial = mepoconfig.get('clone','partial')
@@ -30,6 +33,7 @@ def run(args):
             print(f'Found partial clone type [{partial}] in .mepoconfig')
     else:
         partial = None
+
 
     # If you pass in a config, with clone, it could be outside the repo.
     # So use the full path
@@ -82,9 +86,18 @@ def run(args):
             version = comp.version.name
             version = version.replace('origin/','')
             recurse = comp.recurse_submodules
+
+            # According to Git, treeless clones do not interact well with
+            # submodules. So we need to see if any comp has the recurse
+            # option set to True. If so, we need to clone that comp "normally"
+
+            _partial = None if partial == 'treeless' and recurse else partial
+
+            print(f'Cloning {comp.name} {version}. Recurse: {recurse}. Partial: {_partial}')
+
             # We need the type to handle hashes in components.yaml
             type = comp.version.type
-            git.clone(version,recurse,type,comp.name,partial)
+            git.clone(version,recurse,type,comp.name,_partial)
             if comp.sparse:
                 git.sparsify(comp.sparse)
             print_clone_info(comp, max_namelen)
@@ -104,10 +117,14 @@ def print_clone_info(comp, name_width):
 
 def local_clone(url,branch=None,directory=None,partial=None):
     cmd1 = 'git clone '
+
     if partial == 'blobless':
         cmd1 += '--filter=blob:none '
     elif partial == 'treeless':
         cmd1 += '--filter=tree:0 '
+    else:
+        partial = None
+
     if branch:
         cmd1 += '--branch {} '.format(branch)
     cmd1 += '--quiet {}'.format(url)


### PR DESCRIPTION
This PR adds a protection so that treeless clones do not happen when a repo has submodules. Git said that is strongly not recommended (see https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/).

Also, add a `--partial=off` option so a user can override the `.mepoconfig` behaviour.