### PR TITLE
Patch for reading mepo1 state

### DIFF
--- a/src/mepo/state/state.py
+++ b/src/mepo/state/state.py
@@ -75,8 +75,23 @@ class MepoState(object):
     def read_state(cls):
         if not cls.exists():
             raise StateDoesNotExistError('Error! mepo state does not exist')
-        with open(cls.get_file(), 'rb') as fin:
-            allcomps = pickle.load(fin)
+        try:
+            with open(cls.get_file(), 'rb') as fin:
+                allcomps = pickle.load(fin)
+        except ModuleNotFoundError:
+            # Patch start
+            # mepo1 to mepo2 includes reanming
+            #   mepo.d/state/state.py -> src/mepo/state/state.py
+            # Since pickle requires that "the class definition must be importable
+            # and live in the same module as when the object was stored", we need to
+            # patch sys.modules to be able to read mepo1 state
+            import mepo.state
+            import mepo.utilities
+            sys.modules['state'] = mepo.state
+            sys.modules['utilities'] = mepo.utilities
+            # Patch end
+            with open(cls.get_file(), 'rb') as fin:
+                allcomps = pickle.load(fin)
         return allcomps
 
     @classmethod


### PR DESCRIPTION
`mepo1` to `mepo2` transition includes a renaming of directories (`mepo.d` -> `src/mepo`). Since pickle requires that

> the class definition must be importable and live in the same module as when the object was stored

we need to patch `sys.modules` to be able to read `mepo1` state (https://stackoverflow.com/a/2121886)