### PR TITLE
Fixed a bug in mepo state creation during 'mepo update-state'

### DIFF
--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -54,6 +54,8 @@ pylint==3.2.0
 pyyaml==6.0.1
     # via mepo
     # via pre-commit
+setuptools==70.0.0
+    # via nodeenv
 tomli==2.0.1
     # via black
     # via pylint
@@ -65,5 +67,3 @@ typing-extensions==4.11.0
     # via pylint
 virtualenv==20.26.2
     # via pre-commit
-setuptools==70.0.0
-    # via nodeenv

--- a/src/mepo/state.py
+++ b/src/mepo/state.py
@@ -131,8 +131,14 @@ class MepoState(object):
         if cls.state_exists():
             state_dir = cls.get_dir()
             pattern = os.path.join(cls.get_dir(), "state.*.json")
-            states = [os.path.basename(x) for x in glob.glob(os.path.join(pattern))]
+            states = [os.path.basename(x) for x in glob.glob(pattern)]
             new_state_id = max([int(x.split(".")[1]) for x in states]) + 1
+            state_filename = "state." + str(new_state_id) + ".json"
+        elif cls.state_exists(old_style=True):
+            state_dir = cls.get_dir()
+            pattern = os.path.join(cls.get_dir(), "state.*.pkl")
+            states = [os.path.basename(x) for x in glob.glob(pattern)]
+            new_state_id = max([int(x.split(".")[1]) for x in states])
             state_filename = "state." + str(new_state_id) + ".json"
         else:
             state_dir = os.path.join(os.getcwd(), cls.__state_dir_name)


### PR DESCRIPTION
Fixed a bug where the new mepo state creation during 'mepo update-state' was following the codepath for the case when mepo state does not exist.