### PR TITLE
A bug fix and '--serial' option for status and restore-state commands

### DIFF
--- a/src/mepo/cmdline/parser.py
+++ b/src/mepo/cmdline/parser.py
@@ -155,10 +155,13 @@ class MepoArgParser:
         )
 
     def __restore_state(self):
-        _ = self.subparsers.add_parser(
+        restore_state = self.subparsers.add_parser(
             "restore-state",
             description="Restores all components to the last saved state.",
             aliases=mepoconfig.get_command_alias("restore-state"),
+        )
+        restore_state.add_argument(
+            "--serial", action="store_true", help="Run the serial version."
         )
 
     def __diff(self):

--- a/src/mepo/cmdline/parser.py
+++ b/src/mepo/cmdline/parser.py
@@ -150,6 +150,9 @@ class MepoArgParser:
         status.add_argument(
             "--hashes", action="store_true", help="Print the exact hash of the HEAD."
         )
+        status.add_argument(
+            "--serial", action="store_true", help="Run the serial version."
+        )
 
     def __restore_state(self):
         _ = self.subparsers.add_parser(

--- a/src/mepo/command/restore-state.py
+++ b/src/mepo/command/restore-state.py
@@ -9,8 +9,13 @@ from ..utilities import colors
 def run(args):
     print("Checking status...", flush=True)
     allcomps = MepoState.read_state()
-    with mp.Pool() as pool:
-        result = pool.map(check_component_status, allcomps)
+    if args.serial:
+        result = []
+        for comp in allcomps:
+            result.append(check_component_status(comp))
+    else:
+        with mp.Pool() as pool:
+            result = pool.map(check_component_status, allcomps)
     restore_state(allcomps, result)
 
 

--- a/src/mepo/state.py
+++ b/src/mepo/state.py
@@ -121,6 +121,8 @@ class MepoState(object):
             cls.__mepo1_patch()
             with open(cls.get_file(old_style=True), "rb") as fin:
                 allcomps = pickle.load(fin)
+            for comp in allcomps:
+                comp.local = os.path.join(cls.get_root_dir(), comp.local)
         else:
             raise StateDoesNotExistError("Error! mepo state does not exist")
         return allcomps

--- a/tests/test_mepo_commands.py
+++ b/tests/test_mepo_commands.py
@@ -99,6 +99,7 @@ class TestMepoCommands(unittest.TestCase):
             ignore_permissions=False,
             nocolor=True,
             hashes=False,
+            serial=False,
         )
         with contextlib.redirect_stdout(io.StringIO()) as output:
             mepo_status.run(args)
@@ -110,8 +111,9 @@ class TestMepoCommands(unittest.TestCase):
 
     def __mepo_restore_state(self):
         os.chdir(self.__class__.fixture_dir)
+        args = SimpleNamespace(serial=False)
         with contextlib.redirect_stdout(io.StringIO()) as _:
-            mepo_restore_state.run(SimpleNamespace())
+            mepo_restore_state.run(args)
         self.__mepo_status(self.__class__.output_clone_status)
 
     def test_list(self):


### PR DESCRIPTION
- Bugfix - convert the local path of the repos to absolute after reading the state, in case of old style state as well.
- `--serial` option for `status` and `restore-state` -  running `mepo status` on a mac seemed to cause issues for the case of an old style state. Somehow the modification of sys.modules, to be able to read `pickle`d state, do not percolate down to the processes spawned by multiprocessing. To work around this issue, added a '--serial' option to the `status` and `restore-state` commands.

