### PR TITLE
Store complete remote url in state file

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -26,6 +26,5 @@ jobs:
 
     - name: Run tests
       run: |
-        source .venv/bin/activate
-        python tests/test_mepo_commands.py -v
+        rye test -v
       timeout-minutes: 5

--- a/etc/mepo-completion.bash
+++ b/etc/mepo-completion.bash
@@ -2,18 +2,17 @@
 
 # complete -W "init clone status checkout branch diff where whereis history" mepo
 
+# SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+SCRIPT_DIR=$(dirname $(realpath $0))
+
 _get_mepo_commands() {
     local mepo_cmd_list=""
-    if [[ "$OSTYPE" == "darwin"* ]]
-    then
-       local mepodir=$(dirname $(readlink $(which mepo)))
-    else
-       local mepodir=$(dirname $(readlink -f $(which mepo)))
-    fi
-    for mydir in $(ls -d ${mepodir}/mepo.d/command/*/); do
-        if [[ $mydir != *"__pycache__"* ]]; then
-            mepo_cmd_list+=" $(basename $mydir)"
-        fi
+    local mepo_dir=$(python3 $SCRIPT_DIR/mepo-path.py)
+    for pyfile in $(ls ${mepo_dir}/command/*.py*); do
+	command=${pyfile##*/} # remove path
+	command=${command%.*} # remove extension
+	command=$(echo $command | cut -d _ -f 1)
+        mepo_cmd_list+=" $command"
     done
     echo ${mepo_cmd_list}
 }

--- a/etc/mepo-path.py
+++ b/etc/mepo-path.py
@@ -1,0 +1,3 @@
+import os, mepo
+
+print(os.path.dirname(mepo.__file__))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ authors = [{name="GMAO SI Team", email="siteam@gmao.gsfc.nasa.gov"}]
 dependencies = [
     "pyyaml>=6.0.1",
     "colorama>=0.4.6",
-    "pytest>=8.3.3",
 ]
 readme = "README.md"
 license = "Apache-2.0"
@@ -24,6 +23,7 @@ dev-dependencies = [
     "flake8>=7.0.0",
     "pre-commit>=3.7.1",
     "mdutils>=1.6.0",
+    "pytest>=8.2.1",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ authors = [{name="GMAO SI Team", email="siteam@gmao.gsfc.nasa.gov"}]
 dependencies = [
     "pyyaml>=6.0.1",
     "colorama>=0.4.6",
+    "pytest>=8.3.3",
 ]
 readme = "README.md"
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mepo"
-version = "2.0.0"
+version = "2.1.0"
 description = "A tool for managing (m)ultiple r(epo)s"
 authors = [{name="GMAO SI Team", email="siteam@gmao.gsfc.nasa.gov"}]
 dependencies = [

--- a/src/mepo/command/update-state.py
+++ b/src/mepo/command/update-state.py
@@ -1,6 +1,9 @@
 """Permanently convert mepo1 state to mepo2 state"""
 
+from urllib.parse import urljoin
+
 from ..state import MepoState
+from ..git import get_current_remote_url
 
 
 def run(_):
@@ -9,6 +12,9 @@ def run(_):
         # mepo2 style does not exist
         allcomps = MepoState.read_state()
         MepoState.mepo1_patch_undo()
+        for comp in allcomps:
+            if comp.remote.startswith("../"):
+                comp.remote = urljoin(get_current_remote_url() + "/", comp.remote)
         # Write new state
         MepoState.write_state(allcomps)
         print("\nConverted mepo1 state to mepo2\n")

--- a/src/mepo/component.py
+++ b/src/mepo/component.py
@@ -1,6 +1,7 @@
 import os
 import shlex
 
+from dataclasses import dataclass
 from urllib.parse import urljoin
 
 from .utilities import shellcmd
@@ -10,6 +11,7 @@ from .utilities.version import MepoVersion
 last_node_list = []
 
 
+@dataclass(eq=True)
 class MepoComponent(object):
 
     __slots__ = [
@@ -53,19 +55,6 @@ class MepoComponent(object):
             f"  recurse_submodules: {self.recurse_submodules}\n"
             f"  fixture: {self.fixture}\n"
             f"  ignore_submodules: {_ignore_submodules}"
-        )
-
-    def __eq__(self, other):
-        return (
-            self.name == other.name
-            and self.local == other.local
-            and self.remote == other.remote
-            and self.version == other.version
-            and self.sparse == other.sparse
-            and self.develop == other.develop
-            and self.recurse_submodules == other.recurse_submodules
-            and self.fixture == other.fixture
-            and self.ignore_submodules == other.recurse_submodules
         )
 
     def __set_original_version(self, comp_details):

--- a/src/mepo/component.py
+++ b/src/mepo/component.py
@@ -4,6 +4,7 @@ import shlex
 from dataclasses import dataclass
 from urllib.parse import urljoin
 
+from .git import get_current_remote_url
 from .utilities import shellcmd
 from .utilities.version import MepoVersion
 
@@ -173,12 +174,6 @@ class MepoComponent(object):
                 v = list(v)
             d.update({k: v})
         return d
-
-
-def get_current_remote_url():
-    cmd = "git remote get-url origin"
-    output = shellcmd.run(shlex.split(cmd), output=True).strip()
-    return output
 
 
 def stylize_local_path(local_path, style):

--- a/src/mepo/component.py
+++ b/src/mepo/component.py
@@ -1,7 +1,7 @@
 import os
 import shlex
 
-from urllib.parse import urlparse
+from urllib.parse import urljoin
 
 from .utilities import shellcmd
 from .utilities.version import MepoVersion
@@ -106,10 +106,7 @@ class MepoComponent(object):
         # local/remote - start
         if self.fixture:
             self.local = "."
-            repo_url = get_current_remote_url()
-            p = urlparse(repo_url)
-            last_url_node = p.path.rsplit("/")[-1]
-            self.remote = "../" + last_url_node
+            self.remote = get_current_remote_url()
         else:
             # Assume the flag for repostories is commercial-at
             repo_flag = "@"
@@ -141,16 +138,17 @@ class MepoComponent(object):
             # print(f'final self.local: {self.local}')
 
             self.remote = comp_details["remote"]
+            if self.remote.startswith("../"):
+                self.remote = urljoin(get_current_remote_url() + "/", self.remote)
         # local/remote - end
-        self.sparse = comp_details.get("sparse", None)  # sparse is optional
-        self.develop = comp_details.get("develop", None)  # develop is optional
-        self.recurse_submodules = comp_details.get(
-            "recurse_submodules", None
-        )  # recurse_submodules is optional
-        self.ignore_submodules = comp_details.get(
-            "ignore_submodules", None
-        )  # ignore_submodules is optional
+
+        # Optionals
+        self.sparse = comp_details.get("sparse", None)
+        self.develop = comp_details.get("develop", None)
+        self.recurse_submodules = comp_details.get("recurse_submodules", None)
+        self.ignore_submodules = comp_details.get("ignore_submodules", None)
         self.__set_original_version(comp_details)
+
         return self
 
     def to_registry_format(self):

--- a/src/mepo/component.py
+++ b/src/mepo/component.py
@@ -55,6 +55,19 @@ class MepoComponent(object):
             f"  ignore_submodules: {_ignore_submodules}"
         )
 
+    def __eq__(self, other):
+        return (
+            self.name == other.name
+            and self.local == other.local
+            and self.remote == other.remote
+            and self.version == other.version
+            and self.sparse == other.sparse
+            and self.develop == other.develop
+            and self.recurse_submodules == other.recurse_submodules
+            and self.fixture == other.fixture
+            and self.ignore_submodules == other.recurse_submodules
+        )
+
     def __set_original_version(self, comp_details):
         if self.fixture:
             cmd_if_branch = "git symbolic-ref HEAD"

--- a/src/mepo/component.py
+++ b/src/mepo/component.py
@@ -27,16 +27,27 @@ class MepoComponent(object):
         "ignore_submodules",
     ]
 
-    def __init__(self):
-        self.name = None
-        self.local = None
-        self.remote = None
-        self.version = None
-        self.sparse = None
-        self.develop = None
-        self.recurse_submodules = None
-        self.fixture = None
-        self.ignore_submodules = None
+    def __init__(
+        self,
+        name=None,
+        local=None,
+        remote=None,
+        version=None,
+        sparse=None,
+        develop=None,
+        recurse_submodules=None,
+        fixture=None,
+        ignore_submodules=None,
+    ):
+        self.name = name
+        self.local = local
+        self.remote = remote
+        self.version = version
+        self.sparse = sparse
+        self.develop = develop
+        self.recurse_submodules = recurse_submodules
+        self.fixture = fixture
+        self.ignore_submodules = ignore_submodules
 
     def __repr__(self):
         # Older mepo clones will not have ignore_submodules in comp, so

--- a/src/mepo/git.py
+++ b/src/mepo/git.py
@@ -30,13 +30,7 @@ class GitRepository:
 
     def __init__(self, remote_url, local_path):
         self.__local = local_path
-
-        if remote_url.startswith(".."):
-            rel_remote = os.path.basename(remote_url)
-            fixture_url = get_current_remote_url()
-            self.__remote = urljoin(fixture_url, rel_remote)
-        else:
-            self.__remote = remote_url
+        self.__remote = remote_url
 
         root_dir = MepoState.get_root_dir()
         full_local_path = os.path.normpath(os.path.join(root_dir, local_path))
@@ -571,9 +565,3 @@ class GitRepository:
             name = hash_out.rstrip()
             tYpe = "h"
         return (name, tYpe, detached)
-
-
-def get_current_remote_url():
-    cmd = "git remote get-url origin"
-    output = shellcmd.run(shlex.split(cmd), output=True).strip()
-    return output

--- a/src/mepo/git.py
+++ b/src/mepo/git.py
@@ -34,8 +34,6 @@ class GitRepository:
     __slots__ = ["__local_path_abs", "__remote", "__git"]
 
     def __init__(self, remote_url, local_path_abs):
-        if local_path_abs.startswith("../"):
-            raise ValueError("local path cannot be relative")
         self.__local_path_abs = local_path_abs
         self.__remote = remote_url
         self.__git = 'git -C "{}"'.format(self.__local_path_abs)

--- a/src/mepo/git.py
+++ b/src/mepo/git.py
@@ -5,7 +5,6 @@ import subprocess as sp
 
 from urllib.parse import urljoin
 
-from .state import MepoState
 from .utilities import shellcmd
 from .utilities import colors
 from .utilities.exceptions import RepoAlreadyClonedError
@@ -21,27 +20,28 @@ def get_editor():
     return result.stdout.rstrip().decode("utf-8")  # byte to utf-8
 
 
+def get_current_remote_url():
+    cmd = "git remote get-url origin"
+    output = shellcmd.run(shlex.split(cmd), output=True).strip()
+    return output
+
+
 class GitRepository:
     """
     Class to consolidate git commands
     """
 
-    __slots__ = ["__local", "__full_local_path", "__remote", "__git"]
+    __slots__ = ["__local_path_abs", "__remote", "__git"]
 
-    def __init__(self, remote_url, local_path):
-        self.__local = local_path
+    def __init__(self, remote_url, local_path_abs):
+        if local_path_abs.startswith("../"):
+            raise ValueError("local path cannot be relative")
+        self.__local_path_abs = local_path_abs
         self.__remote = remote_url
-
-        root_dir = MepoState.get_root_dir()
-        full_local_path = os.path.normpath(os.path.join(root_dir, local_path))
-        self.__full_local_path = full_local_path
-        self.__git = 'git -C "{}"'.format(self.__full_local_path)
+        self.__git = 'git -C "{}"'.format(self.__local_path_abs)
 
     def get_local_path(self):
-        return self.__local
-
-    def get_full_local_path(self):
-        return self.__full_local_path
+        return self.__local_path_abs
 
     def get_remote_url(self):
         return self.__remote
@@ -57,15 +57,15 @@ class GitRepository:
         if recurse:
             cmd1 += "--recurse-submodules "
 
-        cmd1 += "--quiet {} {}".format(self.__remote, self.__full_local_path)
+        cmd1 += "--quiet {} {}".format(self.__remote, self.__local_path_abs)
         try:
             shellcmd.run(shlex.split(cmd1))
         except sp.CalledProcessError:
             raise RepoAlreadyClonedError(f"Error! Repo [{comp_name}] already cloned")
 
-        cmd2 = "git -C {} checkout {}".format(self.__full_local_path, version)
+        cmd2 = "git -C {} checkout {}".format(self.__local_path_abs, version)
         shellcmd.run(shlex.split(cmd2))
-        cmd3 = "git -C {} checkout --detach".format(self.__full_local_path)
+        cmd3 = "git -C {} checkout --detach".format(self.__local_path_abs)
         shellcmd.run(shlex.split(cmd3))
 
         # NOTE: The above looks odd because of a quirk of git. You can't do
@@ -82,7 +82,7 @@ class GitRepository:
             shellcmd.run(shlex.split(cmd2))
 
     def sparsify(self, sparse_config):
-        dst = os.path.join(self.__full_local_path, ".git", "info", "sparse-checkout")
+        dst = os.path.join(self.__local_path_abs, ".git", "info", "sparse-checkout")
         os.makedirs(os.path.dirname(dst), exist_ok=True)
         shutil.copy(sparse_config, dst)
         cmd1 = self.__git + " config core.sparseCheckout true"
@@ -138,7 +138,7 @@ class GitRepository:
         return output.rstrip()
 
     def run_diff(self, args=None, ignore_submodules=False):
-        cmd = "git -C {}".format(self.__full_local_path)
+        cmd = "git -C {}".format(self.__local_path_abs)
         if args.ignore_permissions:
             cmd += " -c core.fileMode=false"
         cmd += " diff --color"
@@ -177,7 +177,7 @@ class GitRepository:
                 cmd = [
                     "git",
                     "-C",
-                    self.__full_local_path,
+                    self.__local_path_abs,
                     "tag",
                     "-a",
                     "-F",
@@ -188,7 +188,7 @@ class GitRepository:
                 cmd = [
                     "git",
                     "-C",
-                    self.__full_local_path,
+                    self.__local_path_abs,
                     "tag",
                     "-a",
                     "-m",
@@ -198,7 +198,7 @@ class GitRepository:
             else:
                 raise Exception("This should not happen")
         else:
-            cmd = ["git", "-C", self.__full_local_path, "tag", tag_name]
+            cmd = ["git", "-C", self.__local_path_abs, "tag", tag_name]
         shellcmd.run(cmd)
 
     def delete_branch(self, branch_name, force):
@@ -235,7 +235,7 @@ class GitRepository:
         return status, ref_type
 
     def check_status(self, ignore_permissions=False, ignore_submodules=False):
-        cmd = "git -C {}".format(self.__full_local_path)
+        cmd = "git -C {}".format(self.__local_path_abs)
         if ignore_permissions:
             cmd += " -c core.fileMode=false"
         cmd += " status --porcelain=v2"
@@ -482,9 +482,9 @@ class GitRepository:
 
     def commit_files(self, message, tf_file=None):
         if tf_file:
-            cmd = ["git", "-C", self.__full_local_path, "commit", "-F", tf_file]
+            cmd = ["git", "-C", self.__local_path_abs, "commit", "-F", tf_file]
         elif message:
-            cmd = ["git", "-C", self.__full_local_path, "commit", "-m", message]
+            cmd = ["git", "-C", self.__local_path_abs, "commit", "-m", message]
         else:
             raise Exception("This should not happen")
         shellcmd.run(cmd)

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -19,17 +19,17 @@ def get_registry():
 
 
 def get_fvdycore_component():
-    comp = MepoComponent()
-    comp.name = "fvdycore"
-    comp.local = "./src/Components/@FVdycoreCubed_GridComp/@fvdycore"
-    comp.remote = "https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere.git"
-    comp.version = MepoVersion(name="geos/v1.3.0", type="t", detached=True)
-    comp.sparse = None
-    comp.develop = "geos/develop"
-    comp.recurse_submodules = None
-    comp.fixture = False
-    comp.ignore_submodules = None
-    return comp
+    return MepoComponent(
+        name="fvdycore",
+        local="./src/Components/@FVdycoreCubed_GridComp/@fvdycore",
+        remote="https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere.git",
+        version=MepoVersion(name="geos/v1.3.0", type="t", detached=True),
+        sparse=None,
+        develop="geos/develop",
+        recurse_submodules=None,
+        fixture=False,
+        ignore_submodules=None,
+    )
 
 
 def get_fvdycore_serialized():

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -18,17 +18,28 @@ def get_registry():
     return Registry(registry).read_file()
 
 
-def get_fvdycore_component():
+def __get_fvdycore_component_without_remote():
     comp = MepoComponent()
     comp.name = "fvdycore"
     comp.local = "./src/Components/@FVdycoreCubed_GridComp/@fvdycore"
-    comp.remote = "git@github.com:GEOS-ESM/GFDL_atmos_cubed_sphere.git"
     comp.version = MepoVersion(name="geos/v1.3.0", type="t", detached=True)
     comp.sparse = None
     comp.develop = "geos/develop"
     comp.recurse_submodules = None
     comp.fixture = False
     comp.ignore_submodules = None
+    return comp
+
+
+def get_fvdycore_component_ssh():
+    comp = __get_fvdycore_component_without_remote()
+    comp.remote = "git@github.com:GEOS-ESM/GFDL_atmos_cubed_sphere.git"
+    return comp
+
+
+def get_fvdycore_component_https():
+    comp = __get_fvdycore_component_without_remote()
+    comp.remote = "https://github.com/GEOS-ESM/FVdycoreCubed_GridComp.git"
     return comp
 
 
@@ -64,5 +75,8 @@ def test_MepoComponent():
     for name, comp in registry.items():
         if name == "fvdycore":
             fvdycore = MepoComponent().registry_to_component(name, comp, None)
-    assert fvdycore == get_fvdycore_component()
+    assert (
+        fvdycore == get_fvdycore_component_ssh()
+        or fvdycore == get_fvdycore_component_https()
+    )
     assert fvdycore.serialize() == get_fvdycore_serialized()

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -64,8 +64,5 @@ def test_MepoComponent():
     for name, comp in registry.items():
         if name == "fvdycore":
             fvdycore = MepoComponent().registry_to_component(name, comp, None)
-            # comp = MepoComponent().registry_to_component(name, comp, None)
-            # assert comp == get_fvdycore_component()
-            # complist.append(comp)
     assert fvdycore == get_fvdycore_component()
     assert fvdycore.serialize() == get_fvdycore_serialized()

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -22,7 +22,7 @@ def get_fvdycore_component():
     comp = MepoComponent()
     comp.name = "fvdycore"
     comp.local = "./src/Components/@FVdycoreCubed_GridComp/@fvdycore"
-    comp.remote = "https://github.com/GEOS-ESM/FVdycoreCubed_GridComp.git"
+    comp.remote = "https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere.git"
     comp.version = MepoVersion(name="geos/v1.3.0", type="t", detached=True)
     comp.sparse = None
     comp.develop = "geos/develop"
@@ -36,7 +36,7 @@ def get_fvdycore_serialized():
     return {
         "name": "fvdycore",
         "local": "./src/Components/@FVdycoreCubed_GridComp/@fvdycore",
-        "remote": "https://github.com/GEOS-ESM/FVdycoreCubed_GridComp.git",
+        "remote": "https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere.git",
         "version": ["geos/v1.3.0", "t", True],
         "sparse": None,
         "develop": "geos/develop",

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -18,10 +18,11 @@ def get_registry():
     return Registry(registry).read_file()
 
 
-def __get_fvdycore_component_without_remote():
+def get_fvdycore_component():
     comp = MepoComponent()
     comp.name = "fvdycore"
     comp.local = "./src/Components/@FVdycoreCubed_GridComp/@fvdycore"
+    comp.remote = "https://github.com/GEOS-ESM/FVdycoreCubed_GridComp.git"
     comp.version = MepoVersion(name="geos/v1.3.0", type="t", detached=True)
     comp.sparse = None
     comp.develop = "geos/develop"
@@ -31,23 +32,11 @@ def __get_fvdycore_component_without_remote():
     return comp
 
 
-def get_fvdycore_component_ssh():
-    comp = __get_fvdycore_component_without_remote()
-    comp.remote = "git@github.com:GEOS-ESM/GFDL_atmos_cubed_sphere.git"
-    return comp
-
-
-def get_fvdycore_component_https():
-    comp = __get_fvdycore_component_without_remote()
-    comp.remote = "https://github.com/GEOS-ESM/FVdycoreCubed_GridComp.git"
-    return comp
-
-
 def get_fvdycore_serialized():
     return {
         "name": "fvdycore",
         "local": "./src/Components/@FVdycoreCubed_GridComp/@fvdycore",
-        "remote": "git@github.com:GEOS-ESM/GFDL_atmos_cubed_sphere.git",
+        "remote": "https://github.com/GEOS-ESM/FVdycoreCubed_GridComp.git",
         "version": ["geos/v1.3.0", "t", True],
         "sparse": None,
         "develop": "geos/develop",
@@ -75,8 +64,5 @@ def test_MepoComponent():
     for name, comp in registry.items():
         if name == "fvdycore":
             fvdycore = MepoComponent().registry_to_component(name, comp, None)
-    assert (
-        fvdycore == get_fvdycore_component_ssh()
-        or fvdycore == get_fvdycore_component_https()
-    )
+    assert fvdycore == get_fvdycore_component
     assert fvdycore.serialize() == get_fvdycore_serialized()

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -1,0 +1,71 @@
+import os
+
+from mepo.component import stylize_local_path
+from mepo.component import MepoComponent
+from mepo.registry import Registry
+from mepo.utilities.version import MepoVersion
+
+from _pytest.assertion import truncate
+
+truncate.DEFAULT_MAX_LINES = 9999
+truncate.DEFAULT_MAX_CHARS = 9999
+
+TEST_DIR = os.path.dirname(os.path.realpath(__file__))
+
+
+def get_registry():
+    registry = os.path.join(TEST_DIR, "input", "components.yaml")
+    return Registry(registry).read_file()
+
+
+def get_fvdycore_component():
+    comp = MepoComponent()
+    comp.name = "fvdycore"
+    comp.local = "./src/Components/@FVdycoreCubed_GridComp/@fvdycore"
+    comp.remote = "git@github.com:GEOS-ESM/GFDL_atmos_cubed_sphere.git"
+    comp.version = MepoVersion(name="geos/v1.3.0", type="t", detached=True)
+    comp.sparse = None
+    comp.develop = "geos/develop"
+    comp.recurse_submodules = None
+    comp.fixture = False
+    comp.ignore_submodules = None
+    return comp
+
+
+def get_fvdycore_serialized():
+    return {
+        "name": "fvdycore",
+        "local": "./src/Components/@FVdycoreCubed_GridComp/@fvdycore",
+        "remote": "git@github.com:GEOS-ESM/GFDL_atmos_cubed_sphere.git",
+        "version": ["geos/v1.3.0", "t", True],
+        "sparse": None,
+        "develop": "geos/develop",
+        "recurse_submodules": None,
+        "fixture": False,
+        "ignore_submodules": None,
+    }
+
+
+def test_stylize_local_path():
+    local_path = "./src/Shared/@GMAO_Shared/@GEOS_Util"
+    output = stylize_local_path(local_path, None)
+    assert output == local_path
+    output = stylize_local_path(local_path, "prefix")
+    assert output == local_path
+    output = stylize_local_path(local_path, "naked")
+    assert output == "./src/Shared/@GMAO_Shared/GEOS_Util"
+    output = stylize_local_path(local_path, "postfix")
+    assert output == "./src/Shared/@GMAO_Shared/GEOS_Util@"
+
+
+def test_MepoComponent():
+    registry = get_registry()
+    complist = list()
+    for name, comp in registry.items():
+        if name == "fvdycore":
+            fvdycore = MepoComponent().registry_to_component(name, comp, None)
+            # comp = MepoComponent().registry_to_component(name, comp, None)
+            # assert comp == get_fvdycore_component()
+            # complist.append(comp)
+    assert fvdycore == get_fvdycore_component()
+    assert fvdycore.serialize() == get_fvdycore_serialized()

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -64,5 +64,5 @@ def test_MepoComponent():
     for name, comp in registry.items():
         if name == "fvdycore":
             fvdycore = MepoComponent().registry_to_component(name, comp, None)
-    assert fvdycore == get_fvdycore_component
+    assert fvdycore == get_fvdycore_component()
     assert fvdycore.serialize() == get_fvdycore_serialized()

--- a/tests/test_mepo_commands.py
+++ b/tests/test_mepo_commands.py
@@ -337,7 +337,7 @@ class TestMepoCommands(unittest.TestCase):
             self.__class__.__mepo_clone()
 
     def test_mepo_version(self):
-        self.assertEqual(get_mepo_version(), "2.0.0")
+        self.assertEqual(get_mepo_version(), "2.1.0")
 
     def tearDown(self):
         pass

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,19 @@
+import os
+
+from mepo.registry import Registry
+
+TEST_DIR = os.path.dirname(os.path.realpath(__file__))
+
+
+def get_ecbuild_details():
+    return {
+        "local": "./@cmake/@ecbuild",
+        "remote": "../ecbuild.git",
+        "tag": "geos/v1.2.0",
+    }
+
+
+def test_registry():
+    registry = os.path.join(TEST_DIR, "input", "components.yaml")
+    a = Registry(registry).read_file()
+    assert a["ecbuild"] == get_ecbuild_details()


### PR DESCRIPTION
- Full path of remote url is now stored in the state file
- Logic to decorate local path based on input `comp style` is moved to a separate function
- Added `pytest`s for Registry and MepoComponent. `pytest` is now a dev dependency in `pyproject.toml`
- Removed MepoState dependence of `git.py`
- Fixed mepo completion