### PR TITLE
Add stash indicator to status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Hidden option `--location` for mepo that returns the path to the mepo directory
+- Added ability to print number of stashes in `mepo status`
 
 ### Changed
 

--- a/tests/test_mepo_commands.py
+++ b/tests/test_mepo_commands.py
@@ -48,7 +48,7 @@ class TestMepoCommands(unittest.TestCase):
     @classmethod
     def __checkout_fixture(cls):
         remote = f"https://github.com/GEOS-ESM/{cls.fixture}.git"
-        git_clone = "git clone "
+        git_clone = "git clone --filter=blob:none "
         if cls.tag:
             git_clone += f"-b {cls.tag}"
         cmd = f"{git_clone} {remote} {cls.fixture_dir}"


### PR DESCRIPTION
Closes #326 

This PR adds a number of stashes indicator to `mepo status`:

```
GEOSchem_GridComp      | (t) v1.14.0 (DH) [stashes: 1]
HEMCO                  | (t) geos/v2.2.3 (DH) [stashes: 1]
geos-chem              | (t) geos/v13.0.0-rc1 (DH)
GOCART                 | (t) sdr_v2.2.1.2 (DH)
QuickChem              | (t) v1.0.0 (DH)
TR                     | (t) v1.2.0 (DH)
GMI                    | (t) v1.3.0 (DH) [stashes: 2]
StratChem              | (t) v1.0.0 (DH)
```