### PR TITLE
Bug fix in git.py::clone - added space for --recurse-submodules

### DIFF
--- a/src/mepo/git.py
+++ b/src/mepo/git.py
@@ -55,7 +55,7 @@ class GitRepository:
         if partial is not None:
             cmd += PARTIAL[partial]
         if recurse is not None:
-            cmd += "--recurse-submodules "
+            cmd += " --recurse-submodules "
         cmd += " --quiet {} {}".format(self.__remote, self.__local_path_abs)
         shellcmd.run(shlex.split(cmd))
 

--- a/tests/test_mepo_clone.py
+++ b/tests/test_mepo_clone.py
@@ -52,6 +52,7 @@ GEOS_Util              | (t) v2.1.3 (DH)
 FMS                    | (t) geos/2019.01.02+noaff.10 (DH)
 FVdycoreCubed_GridComp | (t) v2.12.0 (DH)
 fvdycore               | (t) geos/v2.9.1 (DH)
+mom6                   | (t) geos/v3.3 (DH)
 """
     with contextlib_chdir(FIXTURE_NAME):
         status_output = get_mepo_status()


### PR DESCRIPTION
Fix for #330 

- Added the needed space for `--recurse-submodules`
- Update `clone` test where the fixture being cloned has a component with submodules