### PR TITLE
v1: Make mepo status serial by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Made `mepo status` serial by default due to odd fork-bomb-like behavior on some systems
+
 ### Removed
 
 ## [1.52.0] - 2024-01-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Made `mepo status` serial by default due to odd fork-bomb-like behavior on some systems
-
 ### Removed
+
+## [1.53.0] - 2025-01-06
+
+### Changed
+
+- Made `mepo status` serial by default due to odd fork-bomb-like behavior on some systems
 
 ## [1.52.0] - 2024-01-10
 

--- a/mepo.d/command/status/status.py
+++ b/mepo.d/command/status/status.py
@@ -13,10 +13,14 @@ import shlex
 def run(args):
     print('Checking status...'); sys.stdout.flush()
     allcomps = MepoState.read_state()
-    pool = mp.Pool()
-    atexit.register(pool.close)
-    result = pool.starmap(check_component_status, [(comp, args.ignore_permissions) for comp in allcomps])
-    print_status(allcomps, result, args.nocolor, args.hashes)
+    max_width = max([len(comp.name) for comp in allcomps])
+    for comp in allcomps:
+        result = check_component_status(comp, args.ignore_permissions)
+        print_component_status(comp, result, max_width, args.nocolor, args.hashes)
+    #pool = mp.Pool()
+    #atexit.register(pool.close)
+    #result = pool.starmap(check_component_status, [(comp, args.ignore_permissions) for comp in allcomps])
+    #print_status(allcomps, result, args.nocolor, args.hashes)
 
 def check_component_status(comp, ignore_permissions):
     git = GitRepository(comp.remote, comp.local)
@@ -41,33 +45,35 @@ def check_component_status(comp, ignore_permissions):
 
     return (curr_ver, internal_state_branch_name, git.check_status(ignore_permissions,_ignore_submodules))
 
-def print_status(allcomps, result, nocolor=False, hashes=False):
-    orig_width = len(max([comp.name for comp in allcomps], key=len))
+def print_status(allcomps, result, max_width, nocolor=False, hashes=False):
+    """Print the status of all components"""
     for index, comp in enumerate(allcomps):
         time.sleep(0.025)
-        current_version, internal_state_branch_name, output = result[index]
-        if hashes:
-            comp_path = _get_relative_path(comp.local)
-            comp_hash = shellcmd.run(
-                cmd=shlex.split(f"git -C {comp_path} rev-parse HEAD"),
-                output=True
-            ).replace("\n", "")
-            current_version = f"{current_version} ({comp_hash})"
-        # This should handle tag weirdness...
-        if current_version.split()[1] == comp.version.name:
-            component_name = comp.name
-            width = orig_width
-        # Check to see if the current tag/branch is the same as the
-        # original... if the above check didn't succeed, we are
-        # different and we colorize if asked for
-        elif (internal_state_branch_name not in comp.version.name) and not nocolor:
-            component_name = colors.RED + comp.name + colors.RESET
-            width = orig_width + len(colors.RED) + len(colors.RESET)
-        else:
-            component_name = comp.name
-            width = orig_width
-        FMT0 = '{:<%s.%ss} | {:<s}' % (width, width)
-        print(FMT0.format(component_name, current_version))
-        if (output):
-            for line in output.split('\n'):
-                print('   |', line.rstrip())
+        print_component_status(comp, result[index], max_width, nocolor, hashes)
+
+def print_component_status(comp, result, width, nocolor=False, hashes=False):
+    current_version, internal_state_branch_name, output = result
+    if hashes:
+        comp_path = _get_relative_path(comp.local)
+        comp_hash = shellcmd.run(
+            cmd=shlex.split(f"git -C {comp_path} rev-parse HEAD"),
+            output=True
+        ).replace("\n", "")
+        current_version = f"{current_version} ({comp_hash})"
+    # This should handle tag weirdness...
+    if current_version.split()[1] == comp.version.name:
+        component_name = comp.name
+    # Check to see if the current tag/branch is the same as the
+    # original... if the above check didn't succeed, we are
+    # different and we colorize if asked for
+    elif (internal_state_branch_name not in comp.version.name) and not nocolor:
+        component_name = colors.RED + comp.name + colors.RESET
+        width += len(colors.RED) + len(colors.RESET)
+    else:
+        component_name = comp.name
+    FMT0 = '{:<%s.%ss} | {:<s}' % (width, width)
+    print(FMT0.format(component_name, current_version))
+    if (output):
+        for line in output.split('\n'):
+            print('   |', line.rstrip())
+


### PR DESCRIPTION
It was noticed at NAS that `mepo status` was causing fork-bomb like behavior due to weirdness with Python multiprocessing. Since `mepo status` doesn't really require parallel-ness, we move to serial by default.

This change is essentially a copy of the work of @pchakraborty as seen in the `mepo status --serial` option in mepo v2. 

Since mepo v1 is nigh-dead code, I have not implemented a `--parallel` option here. In the end, it doesn't matter since mepo v2 is just better.