### PR TITLE
v2: Default status and restore-state to serial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-## [2.2.0] - 2024-12-24
+- Moved `mepo status` and `mepo restore-state` to default to their serial variants rather than parallel by default. At the same time, we remove the `--serial` option from these commands and add a `--parallel` option if users want to run them in parallel.
 
+## [2.2.0] - 2024-12-24
 
 ### Added
 

--- a/src/mepo/cmdline/parser.py
+++ b/src/mepo/cmdline/parser.py
@@ -188,7 +188,7 @@ class MepoArgParser:
             "--hashes", action="store_true", help="Print the exact hash of the HEAD."
         )
         status.add_argument(
-            "--serial", action="store_true", help="Run the serial version."
+            "--parallel", action="store_true", help="Run the parallel version."
         )
 
     def __restore_state(self):
@@ -198,7 +198,7 @@ class MepoArgParser:
             aliases=mepoconfig.get_command_alias("restore-state"),
         )
         restore_state.add_argument(
-            "--serial", action="store_true", help="Run the serial version."
+            "--parallel", action="store_true", help="Run the parallel version."
         )
 
     def __diff(self):

--- a/src/mepo/command/restore-state.py
+++ b/src/mepo/command/restore-state.py
@@ -9,13 +9,13 @@ from ..utilities import colors
 def run(args):
     print("Checking status...", flush=True)
     allcomps = MepoState.read_state()
-    if args.serial:
+    if args.parallel:
+        with mp.Pool() as pool:
+            result = pool.map(check_component_status, allcomps)
+    else:
         result = []
         for comp in allcomps:
             result.append(check_component_status(comp))
-    else:
-        with mp.Pool() as pool:
-            result = pool.map(check_component_status, allcomps)
     restore_state(allcomps, result)
 
 

--- a/src/mepo/command/status.py
+++ b/src/mepo/command/status.py
@@ -20,17 +20,17 @@ def run(args):
     allcomps = MepoState.read_state()
     # max_width = len(max([comp.name for comp in allcomps], key=len))
     max_width = max([len(comp.name) for comp in allcomps])
-    if args.serial:
-        for comp in allcomps:
-            result = check_component_status(comp, args.ignore_permissions)
-            print_component_status(comp, result, max_width, args.nocolor, args.hashes)
-    else:
+    if args.parallel:
         with mp.Pool() as pool:
             result = pool.starmap(
                 check_component_status,
                 [(comp, args.ignore_permissions) for comp in allcomps],
             )
         print_status(allcomps, result, max_width, args.nocolor, args.hashes)
+    else:
+        for comp in allcomps:
+            result = check_component_status(comp, args.ignore_permissions)
+            print_component_status(comp, result, max_width, args.nocolor, args.hashes)
 
 
 def check_component_status(comp, ignore_permissions):

--- a/tests/test_mepo_clone.py
+++ b/tests/test_mepo_clone.py
@@ -22,7 +22,7 @@ def get_mepo_status():
         ignore_permissions=False,
         nocolor=True,
         hashes=False,
-        serial=True,
+        parallel=False,
     )
     with contextlib.redirect_stdout(io.StringIO()) as output:
         mepo_status.run(args)

--- a/tests/test_mepo_commands.py
+++ b/tests/test_mepo_commands.py
@@ -100,7 +100,7 @@ class TestMepoCommands(unittest.TestCase):
             ignore_permissions=False,
             nocolor=True,
             hashes=False,
-            serial=False,
+            parallel=True,
         )
         with contextlib.redirect_stdout(io.StringIO()) as output:
             mepo_status.run(args)
@@ -112,7 +112,7 @@ class TestMepoCommands(unittest.TestCase):
 
     def __mepo_restore_state(self):
         os.chdir(self.__class__.fixture_dir)
-        args = SimpleNamespace(serial=False)
+        args = SimpleNamespace(parallel=True)
         with contextlib.redirect_stdout(io.StringIO()) as _:
             mepo_restore_state.run(args)
         self.__mepo_status(self.__class__.output_clone_status)


### PR DESCRIPTION
Closes #337 

As described in #336, `mepo status` in its parallel version was causing fork-bomb-like behavior at NAS. As the parallel version of `status` isn't really that needed on most systems, we instead move to the serial version by default. At the same time, we remove the `--serial` flag and add a `--parallel` flag to allow users to use the old behavior if needed.

I also saw that `restore-state` had a serial/parallel version. So, for completeness, I moved that to serial by default. 

I'm keeping this PR as draft because I know @pchakraborty has tests he does locally with rye, etc. that I haven't quite learned how to do yet. 