### PR TITLE
Add README info for uv

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,24 @@ To install `mepo` using `pip`, run the following command:
 pip install mepo
 ```
 
+### Using uv
+
+#### uv install
+
+You can install `mepo` using the `uv` package manager. To do so, run the following command:
+
+```
+uv install mepo
+```
+
+#### uvx
+
+If you'd like to run `mepo` without installing it, you can use `uvx` to run it directly from the repository:
+
+```
+uvx mepo
+```
+
 ### Homebrew
 
 Using Homebrew, you can install `mepo` by installing from the gmao-si-team tap:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ uv install mepo
 
 #### uvx
 
-If you'd like to run `mepo` without installing it, you can use `uvx` to run it directly from the repository:
+If you'd like to run `mepo` without installing it, you can use `uvx` to run it directly:
 
 ```
 uvx mepo


### PR DESCRIPTION
Was fiddling around with `uv` this weekend. So I added some bits and pieces for using `mepo` with it. I added sections for `uv install` and `uvx` (aka `uv tool run`). 

I suppose there is also `uv tool install`. Not sure if we should add that or not. Maybe? I'll talk with @pchakraborty 