### PR TITLE
Fixes #355. Allow for fixture without develop key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [2.3.1] - 2025-04-16
+
+### Fixed
+
+- Fixed `clone` to allow for fixtures without a `develop:` key in `components.yaml`
+
 ## [2.3.0] - 2025-01-12
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mepo"
-version = "2.3.0"
+version = "2.3.1"
 description = "A tool for managing (m)ultiple r(epo)s"
 authors = [{name="GMAO SI Team", email="siteam@gmao.gsfc.nasa.gov"}]
 dependencies = [

--- a/src/mepo/registry.py
+++ b/src/mepo/registry.py
@@ -37,10 +37,9 @@ class Registry(object):
             if "fixture" in v:
                 # In case of a fixture, develop is the only additional allowed key
                 num_fixtures += 1
-                assert list(v.keys()) == ["fixture"] or list(v.keys()) == [
-                    "fixture",
-                    "develop",
-                ]
+                required_ = ["fixture"]
+                optional_ = ["develop"]
+                assert list(v.keys()) in (required_, required_ + optional_)
             else:
                 # For non-fixture, one and only one of branch/tag/hash allowed
                 xsection = git_tag_types.intersection(set(v.keys()))

--- a/src/mepo/registry.py
+++ b/src/mepo/registry.py
@@ -37,7 +37,10 @@ class Registry(object):
             if "fixture" in v:
                 # In case of a fixture, develop is the only additional allowed key
                 num_fixtures += 1
-                assert list(v.keys()) == ["fixture"] or list(v.keys()) == ["fixture", "develop"]
+                assert list(v.keys()) == ["fixture"] or list(v.keys()) == [
+                    "fixture",
+                    "develop",
+                ]
             else:
                 # For non-fixture, one and only one of branch/tag/hash allowed
                 xsection = git_tag_types.intersection(set(v.keys()))

--- a/src/mepo/registry.py
+++ b/src/mepo/registry.py
@@ -35,9 +35,9 @@ class Registry(object):
         num_fixtures = 0
         for k, v in d.items():
             if "fixture" in v:
-                # In case of a fixture, develop is the only additional key
+                # In case of a fixture, develop is the only additional allowed key
                 num_fixtures += 1
-                assert list(v.keys()) == ["fixture", "develop"]
+                assert list(v.keys()) == ["fixture"] or list(v.keys()) == ["fixture", "develop"]
             else:
                 # For non-fixture, one and only one of branch/tag/hash allowed
                 xsection = git_tag_types.intersection(set(v.keys()))

--- a/tests/test_mepo_commands.py
+++ b/tests/test_mepo_commands.py
@@ -337,7 +337,7 @@ class TestMepoCommands(unittest.TestCase):
             self.__class__.__mepo_clone()
 
     def test_mepo_version(self):
-        self.assertEqual(get_mepo_version(), "2.3.0")
+        self.assertEqual(get_mepo_version(), "2.3.1")
 
     def tearDown(self):
         pass


### PR DESCRIPTION
Closes #355 

This PR allow for fixtures to not have a `develop:` key in `components.yaml`.

I'm keeping draft as for some reason `rye test` isn't working for me locally, so I want @pchakraborty to double check.

Also, maybe a test should be added to test this situation? Dunno if it's worth that...