### PR TITLE
Better handling of input key for dictionary

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -28,5 +28,5 @@ jobs:
 
     - name: Run tests
       run: |
-        uv run pytest -v
+        uv run pytest --durations=0 -v
       timeout-minutes: 5

--- a/src/mepo/command/status.py
+++ b/src/mepo/command/status.py
@@ -143,7 +143,7 @@ def parse_changed_entries(changes):
         elif type_ == "?":
             status_ = statcolor.red("untracked file")
         else:
-            status_ = statcolor.cyan("unknown") + " (contact mepo maintainer)"
+            status_ = statcolor.UNKNOWN
         file_name = item.split()[-1]
         status_string_ = f"{file_name:>{max_len}}: {status_}"
         changes[idx] = status_string_

--- a/src/mepo/utilities/statcolor.py
+++ b/src/mepo/utilities/statcolor.py
@@ -21,6 +21,9 @@ def yellow(string):
     return colors.YELLOW + string + colors.RESET
 
 
+UNKNOWN = cyan("unknown") + " (contact mepo maintainer)"
+
+
 def get_ordinary_change_status(short_status):
     unstaged_ = " with " + red("unstaged changes")
     deleted_unstaged_ = " but " + red("deleted, not staged")
@@ -45,7 +48,7 @@ def get_ordinary_change_status(short_status):
         "TM": green("typechange, staged") + unstaged_,
         "TD": green("typechange, staged") + deleted_unstaged_,
     }
-    return d[short_status]
+    return d.get(short_status, UNKNOWN)
 
 
 def get_renamed_copied_status(short_status, new_file_name):
@@ -62,4 +65,4 @@ def get_renamed_copied_status(short_status, new_file_name):
         "CM": green("copied, staged") + new_file_name_ + unstaged_,
         "CD": green("copied, staged") + new_file_name_ + deleted_unstaged_,
     }
-    return d[short_status]
+    return d.get(short_status, UNKNOWN)

--- a/tests/output/output_branch_list.txt
+++ b/tests/output/output_branch_list.txt
@@ -1,12 +1,9 @@
 ecbuild | * (HEAD detached at geos/v1.3.0)
-        |   release/stable
-        |   remotes/origin/HEAD -> origin/release/stable
+        |   geos/develop
+        |   remotes/origin/HEAD -> origin/geos/develop
         |   remotes/origin/develop
         |   remotes/origin/feature/FindMKL-portability-improvement
-        |   remotes/origin/feature/ecbuild_use_package_quiet
-        |   remotes/origin/feature/netcdf4-cmake
+        |   remotes/origin/geos/develop
         |   remotes/origin/geos/main
         |   remotes/origin/master
         |   remotes/origin/mepo-testing-do-not-delete
-        |   remotes/origin/merge-develop-into-MKL-2025Apr28
-        |   remotes/origin/release/stable


### PR DESCRIPTION
- `src/mepo/utilities/statcolor.py` - return "unknown" if dict key does not exist
- Updated `ecbuild` repository's list of branches, for testing
- `.github/workflows/run-tests.yaml` - added argument to pytest to print test timings