### PR TITLE
Fixes #347. Add blobless option to components.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added ahead/behind info to `mepo status`
+- Added `blobless:` option to `components.yaml` to force blobless cloning for a repo
 
 ### Changed
 

--- a/src/mepo/cmdline/parser.py
+++ b/src/mepo/cmdline/parser.py
@@ -21,7 +21,8 @@ class LocationAction(argparse._StoreTrueAction):
         super().__init__(option_strings, dest, const, help=help)
 
     def __call__(self, parser, namespace, values, option_string=None):
-        import os, sys
+        import os
+        import sys
         import mepo
 
         print(os.path.dirname(mepo.__file__))

--- a/src/mepo/command/clone.py
+++ b/src/mepo/command/clone.py
@@ -92,7 +92,7 @@ def get_registry(arg_registry):
     return registry
 
 
-def clone_components(allcomps, partial):
+def clone_components(allcomps, arg_partial):
     max_namelen = max([len(comp.name) for comp in allcomps])
     for comp in allcomps:
         if comp.fixture:
@@ -101,7 +101,14 @@ def clone_components(allcomps, partial):
         # According to Git, treeless clones do not interact well with
         # submodules. So if any comp has the recurse option set to True,
         # we do a non-partial clone
-        partial = None if partial == "treeless" and recurse_submodules else partial
+        partial = (
+            None if arg_partial == "treeless" and recurse_submodules else arg_partial
+        )
+
+        # The components.yaml can specify blobless as an option so that wins out
+        if comp.blobless:
+            partial = "blobless"
+
         version = comp.version.name
         version = version.replace("origin/", "")
         git = GitRepository(comp.remote, comp.local)

--- a/src/mepo/command/clone.py
+++ b/src/mepo/command/clone.py
@@ -101,9 +101,9 @@ def clone_components(allcomps, arg_partial):
         # According to Git, treeless clones do not interact well with
         # submodules. So if any comp has the recurse option set to True,
         # we do a non-partial clone
-        partial = (
-            None if arg_partial == "treeless" and recurse_submodules else arg_partial
-        )
+        partial = arg_partial
+        if arg_partial == "treeless" and recurse_submodules:
+            partial = None
 
         # The components.yaml can specify blobless as an option so that wins out
         if comp.blobless:

--- a/src/mepo/component.py
+++ b/src/mepo/component.py
@@ -1,5 +1,4 @@
 import os
-import shlex
 
 from dataclasses import dataclass
 from urllib.parse import urljoin
@@ -25,6 +24,7 @@ class MepoComponent(object):
         "recurse_submodules",
         "fixture",
         "ignore_submodules",
+        "blobless",
     ]
 
     def __init__(
@@ -38,6 +38,7 @@ class MepoComponent(object):
         recurse_submodules=None,
         fixture=None,
         ignore_submodules=None,
+        blobless=None,
     ):
         self.name = name
         self.local = local
@@ -48,6 +49,7 @@ class MepoComponent(object):
         self.recurse_submodules = recurse_submodules
         self.fixture = fixture
         self.ignore_submodules = ignore_submodules
+        self.blobless = blobless
 
     def __repr__(self):
         # Older mepo clones will not have ignore_submodules in comp, so
@@ -66,6 +68,7 @@ class MepoComponent(object):
             f"  develop: {self.develop}\n"
             f"  recurse_submodules: {self.recurse_submodules}\n"
             f"  fixture: {self.fixture}\n"
+            f"  blobless: {self.blobless}\n"
             f"  ignore_submodules: {_ignore_submodules}"
         )
 
@@ -131,6 +134,7 @@ class MepoComponent(object):
         self.develop = comp_details.get("develop", None)
         self.recurse_submodules = comp_details.get("recurse_submodules", None)
         self.ignore_submodules = comp_details.get("ignore_submodules", None)
+        self.blobless = comp_details.get("blobless", None)
         # version
         self.__set_original_version(comp_details)
 
@@ -165,6 +169,8 @@ class MepoComponent(object):
                 details["recurse_submodules"] = self.recurse_submodules
             if self.ignore_submodules:
                 details["ignore_submodules"] = self.ignore_submodules
+            if self.blobless:
+                details["blobless"] = self.blobless
         return {self.name: details}
 
     def deserialize(self, d):

--- a/tests/output/output_branch_list.txt
+++ b/tests/output/output_branch_list.txt
@@ -3,6 +3,7 @@ ecbuild | * (HEAD detached at geos/v1.3.0)
         |   remotes/origin/HEAD -> origin/geos/develop
         |   remotes/origin/develop
         |   remotes/origin/feature/FindMKL-portability-improvement
+        |   remotes/origin/geos-develop-before-2025May13-merge
         |   remotes/origin/geos/develop
         |   remotes/origin/geos/main
         |   remotes/origin/master

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -43,6 +43,7 @@ def get_fvdycore_serialized():
         "recurse_submodules": None,
         "fixture": False,
         "ignore_submodules": None,
+        "blobless": None,
     }
 
 
@@ -60,7 +61,6 @@ def test_stylize_local_path():
 
 def test_MepoComponent():
     registry = get_registry()
-    complist = list()
     for name, comp in registry.items():
         if name == "fvdycore":
             fvdycore = MepoComponent().registry_to_component(name, comp, None)


### PR DESCRIPTION
Closes #347 

This PR adds the ability to have in `components.yaml` something like:
```yaml
MAPL:
  local: ./src/Shared/@MAPL
  remote: ../MAPL.git
  tag: v2.55.0
  develop: develop
  blobless: true
```

where that last option is new. This can be used for repos which are either very slow (MAPL) or are very large (ncar_topo) and so blobless clones are more a requirement than a recommendation.