### PR TITLE
Fixes #369. Clarify fixture assertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Clarified error message for `mepo clone` when a fixture is not found in the registry
+
 ## [2.4.0] - 2025-05-30
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Clarified error message for `mepo clone` when a fixture is not found in the registry
+- Clarified error message for `mepo clone` when a fixture is not found in the registry (or more than one fixture is found)
 
 ## [2.4.0] - 2025-05-30
 

--- a/src/mepo/git.py
+++ b/src/mepo/git.py
@@ -291,10 +291,10 @@ class GitRepository:
         else:
             # If we are a branch...
             if commit_type == "b":
-                msgtype = "Branch"
+                #msgtype = "Branch"
                 reftype = "heads"
             elif commit_type == "t":
-                msgtype = "Tag"
+                #msgtype = "Tag"
                 reftype = "tags"
             else:
                 raise RuntimeError("Should not get here")

--- a/src/mepo/registry.py
+++ b/src/mepo/registry.py
@@ -50,11 +50,8 @@ class Registry(object):
         if num_fixtures < 1:
             raise ValueError("At least one fixture must be defined in the registry")
         elif num_fixtures > 1:
-            raise ValueError(
-                "Only one fixture can be defined in the registry, found {}".format(
-                    num_fixtures
-                )
-            )
+            # Use f-string for better readability
+            raise ValueError(f"Only one fixture can be defined in the registry, found {num_fixtures}")
 
     def read_file(self):
         """Call read_yaml, read_json etc. using dispatch pattern"""

--- a/src/mepo/registry.py
+++ b/src/mepo/registry.py
@@ -46,7 +46,15 @@ class Registry(object):
                 if len(xsection) != 1:
                     raise ValueError(f"{k} needs one and only one of {git_tag_types}")
         # Can have one and only one fixture
-        assert num_fixtures == 1
+        # We must have *exactly* one fixture, not zero or more
+        if num_fixtures < 1:
+            raise ValueError("At least one fixture must be defined in the registry")
+        elif num_fixtures > 1:
+            raise ValueError(
+                "Only one fixture can be defined in the registry, found {}".format(
+                    num_fixtures
+                )
+            )
 
     def read_file(self):
         """Call read_yaml, read_json etc. using dispatch pattern"""


### PR DESCRIPTION
Closes #369 

This just cleans up a bit for when a `components.yaml` doesn't have a fixture.

Before:
```
...
  File "/Users/mathomp4/.homebrew/brew/Cellar/mepo/2.4.0/libexec/lib/python3.12/site-packages/mepo/registry.py", line 49, in __validate
    assert num_fixtures == 1
           ^^^^^^^^^^^^^^^^^
AssertionError
```

Now:
```
...
  File "/Users/mathomp4/mepo/src/mepo/registry.py", line 51, in __validate
    raise ValueError("At least one fixture must be defined in the registry")
ValueError: At least one fixture must be defined in the registry
```

I'll let @pchakraborty see if this should be a `ValueError` or something different.