### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/run-formatter.yaml
+++ b/.github/workflows/run-formatter.yaml
@@ -9,10 +9,10 @@ jobs:
     steps:
 
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7
       with:
           version: "latest"
 

--- a/.github/workflows/run-linter.yaml
+++ b/.github/workflows/run-linter.yaml
@@ -8,10 +8,10 @@ jobs:
     name: Lint code
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7
       with:
           version: "latest"
 

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -8,16 +8,16 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "pypy@3.9", "pypy@3.10"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "pypy@3.9", "pypy@3.10"]
 
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
     steps:
 
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7
       with:
           version: "latest"
 

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -6,6 +6,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "pypy@3.10", "pypy@3.11"]

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "pypy@3.10"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "pypy@3.10", "pypy@3.11"]
 
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
     steps:

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "pypy@3.9", "pypy@3.10"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "pypy@3.10"]
 
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,9 @@ mepo = "mepo.__main__:main"
 
 [tool.uv]
 managed = true
-dev-dependencies = [
+
+[dependency-groups]
+dev = [
     "black>=24.4.2",
     "pylint>=3.2.0",
     "flake8>=7.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,9 +8,11 @@ dependencies = [
     "colorama>=0.4.6",
 ]
 readme = "README.md"
-license = "Apache-2.0"
-repository = "https://github.com/GEOS-ESM/mepo.git"
+license = { file = "LICENSE" }
 requires-python = ">= 3.9"
+
+[project.urls]
+Repository = "https://github.com/GEOS-ESM/mepo"
 
 [project.scripts]
 mepo = "mepo.__main__:main"


### PR DESCRIPTION
CI is broken. Let's try and fix...

So far: remove `pypy@3.9`, add `pypy@3.11`.

We also now have:

warning: The `tool.uv.dev-dependencies` field (used in `/Users/mathomp4/mepo/pyproject.toml`) is deprecated and will be removed in a future release; use `dependency-groups.dev` instead

So I'll update that in `pyproject.toml`
