### PR TITLE
Update CI workflows, pyproject.toml, and Homebrew docs

### DIFF
--- a/.github/workflows/run-formatter.yaml
+++ b/.github/workflows/run-formatter.yaml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install uv
         # Pin the action to a full commit SHA rather than a mutable tag like
@@ -19,11 +19,11 @@ jobs:
         # The trailing comment records the human-readable version this SHA
         # corresponds to. To update this action later, use Dependabot or pick
         # a newer release tag, then replace this SHA and update the comment.
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           # Pin uv itself too, so formatting checks do not change just because
           # a new uv release was published.
-          version: "0.11.19"
+          version: "0.11.23"
 
           # This repository currently does not commit uv.lock. Without a lock
           # file, setup-uv's cache key cannot be invalidated reliably, so leave

--- a/.github/workflows/run-formatter.yaml
+++ b/.github/workflows/run-formatter.yaml
@@ -6,21 +6,35 @@ jobs:
   format:
     runs-on: ubuntu-latest
     name: Format code
+
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
 
-    - name: Checkout code
-      uses: actions/checkout@v4
+      - name: Install uv
+        # Pin the action to a full commit SHA rather than a mutable tag like
+        # `v8`. This avoids supply-chain surprises if the tag is moved or a
+        # future release changes behavior unexpectedly.
+        #
+        # The trailing comment records the human-readable version this SHA
+        # corresponds to. To update this action later, use Dependabot or pick
+        # a newer release tag, then replace this SHA and update the comment.
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          # Pin uv itself too, so formatting checks do not change just because
+          # a new uv release was published.
+          version: "0.11.19"
 
-    - name: Install uv
-      uses: astral-sh/setup-uv@v5
-      with:
-          version: "latest"
+          # This repository currently does not commit uv.lock. Without a lock
+          # file, setup-uv's cache key cannot be invalidated reliably, so leave
+          # caching off to avoid noisy cache warnings and stale environments.
+          enable-cache: false
 
-    - name: Install Python and other dependencies
-      run: uv sync
+      - name: Install Python and other dependencies
+        run: uv sync
 
-    - name: Run black
-      run: |
-        source .venv/bin/activate
-        black --check .
-      timeout-minutes: 5
+      - name: Run black
+        # Use `uv run` so this always runs the black installed in the project
+        # environment, without needing to manually activate .venv.
+        run: uv run black --check .
+        timeout-minutes: 5

--- a/.github/workflows/run-linter.yaml
+++ b/.github/workflows/run-linter.yaml
@@ -8,7 +8,7 @@ jobs:
     name: Lint code
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     - name: Install uv
       # Pin the action to a full commit SHA rather than a mutable tag like
@@ -18,11 +18,11 @@ jobs:
       # The trailing comment records the human-readable version this SHA
       # corresponds to. To update this action later, use Dependabot or pick
       # a newer release tag, then replace this SHA and update the comment.
-      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       with:
         # Pin uv itself too, so linting checks do not change just because
         # a new uv release was published.
-        version: "0.11.19"
+        version: "0.11.23"
         # This repository currently does not commit uv.lock. Without a lock
         # file, setup-uv's cache key cannot be invalidated reliably, so leave
         # caching off to avoid noisy cache warnings and stale environments.

--- a/.github/workflows/run-linter.yaml
+++ b/.github/workflows/run-linter.yaml
@@ -8,18 +8,31 @@ jobs:
     name: Lint code
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      # Pin the action to a full commit SHA rather than a mutable tag like
+      # `v8`. This avoids supply-chain surprises if the tag is moved or a
+      # future release changes behavior unexpectedly.
+      #
+      # The trailing comment records the human-readable version this SHA
+      # corresponds to. To update this action later, use Dependabot or pick
+      # a newer release tag, then replace this SHA and update the comment.
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       with:
-          version: "latest"
+        # Pin uv itself too, so linting checks do not change just because
+        # a new uv release was published.
+        version: "0.11.19"
+        # This repository currently does not commit uv.lock. Without a lock
+        # file, setup-uv's cache key cannot be invalidated reliably, so leave
+        # caching off to avoid noisy cache warnings and stale environments.
+        enable-cache: false
 
     - name: Install Python and other dependencies
       run: uv sync
 
     - name: Run pylint
-      run: |
-        source .venv/bin/activate
-        pylint --exit-zero src/mepo
+      # Use `uv run` so this always runs the pylint installed in the project
+      # environment, without needing to manually activate .venv.
+      run: uv run pylint --exit-zero src/mepo
       timeout-minutes: 5

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -9,18 +9,31 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "pypy@3.9", "pypy@3.10"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "pypy@3.10", "pypy@3.11"]
 
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
     steps:
 
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      # Pin the action to a full commit SHA rather than a mutable tag like
+      # `v8`. This avoids supply-chain surprises if the tag is moved or a
+      # future release changes behavior unexpectedly.
+      #
+      # The trailing comment records the human-readable version this SHA
+      # corresponds to. To update this action later, use Dependabot or pick
+      # a newer release tag, then replace this SHA and update the comment.
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       with:
-          version: "latest"
+        # Pin uv itself too, so test results do not change just because
+        # a new uv release was published.
+        version: "0.11.19"
+        # This repository currently does not commit uv.lock. Without a lock
+        # file, setup-uv's cache key cannot be invalidated reliably, so leave
+        # caching off to avoid noisy cache warnings and stale environments.
+        enable-cache: false
 
     - name: Install Python and other dependencies
       run: |

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -15,7 +15,7 @@ jobs:
     steps:
 
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     - name: Install uv
       # Pin the action to a full commit SHA rather than a mutable tag like
@@ -25,11 +25,11 @@ jobs:
       # The trailing comment records the human-readable version this SHA
       # corresponds to. To update this action later, use Dependabot or pick
       # a newer release tag, then replace this SHA and update the comment.
-      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       with:
         # Pin uv itself too, so test results do not change just because
         # a new uv release was published.
-        version: "0.11.19"
+        version: "0.11.23"
         # This repository currently does not commit uv.lock. Without a lock
         # file, setup-uv's cache key cannot be invalidated reliably, so leave
         # caching off to avoid noisy cache warnings and stale environments.

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -6,6 +6,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12", "pypy@3.9", "pypy@3.10"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Updated GitHub Actions CI workflows:
+  - All workflows now use `actions/checkout@v6`
+  - All workflows now use `astral-sh/setup-uv` pinned to a specific version (`0.11.19`) with caching disabled
+  - `run-formatter.yaml` and `run-linter.yaml` now use `uv run` instead of manually activating `.venv`
+  - `run-tests.yaml` Python version matrix updated: added 3.13, 3.14, pypy@3.11; removed pypy@3.9; added `fail-fast: false`
+- Updated `pyproject.toml`:
+  - Migrated `[tool.uv] dev-dependencies` to `[dependency-groups] dev`
+  - Fixed `license` field to use inline table format (`{ file = "LICENSE" }`)
+  - Moved `repository` URL to `[project.urls]`
+- Revised Homebrew installation instructions in `README.md`
+
 ## [2.4.0] - 2025-05-30
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Updated GitHub Actions CI workflows:
-  - All workflows now use `actions/checkout@v6`
-  - All workflows now use `astral-sh/setup-uv` pinned to a specific version (`0.11.19`) with caching disabled
+  - All workflows now use `actions/checkout@v7`
+  - All workflows now use `astral-sh/setup-uv` pinned to a specific SHA (`v8.2.0`) with uv `0.11.23` and caching disabled
   - `run-formatter.yaml` and `run-linter.yaml` now use `uv run` instead of manually activating `.venv`
   - `run-tests.yaml` Python version matrix updated: added 3.13, 3.14, pypy@3.11; removed pypy@3.9; added `fail-fast: false`
 - Updated `pyproject.toml`:

--- a/README.md
+++ b/README.md
@@ -33,17 +33,36 @@ uvx mepo
 
 ### Homebrew
 
-Using Homebrew, you can install `mepo` by installing from the gmao-si-team tap:
+`mepo` is available from the GMAO-SI-Team Homebrew tap:
 
-```
+```sh
 brew install gmao-si-team/packages/mepo
 ```
 
-This is equivalent to running:
+This direct install form is recommended because it tells Homebrew exactly which formula from the tap you want to install.
 
+#### Homebrew tap trust
+
+Newer Homebrew versions warn about formulae from non-official taps. If you enable tap trust checks, or when Homebrew begins requiring them by default, you may need to explicitly trust this formula or tap.
+
+To trust only the `mepo` formula:
+
+```sh
+brew trust --formula gmao-si-team/packages/mepo
 ```
+
+If you prefer to tap the repository first and then install by short name:
+
+```sh
 brew tap gmao-si-team/packages
+brew trust gmao-si-team/packages
 brew install mepo
+```
+
+Only run `brew trust` for taps or formulae whose maintainers and source repository you trust. To remove the tap later:
+
+```sh
+brew untap gmao-si-team/packages
 ```
 
 ### Spack

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,16 +8,20 @@ dependencies = [
     "colorama>=0.4.6",
 ]
 readme = "README.md"
-license = "Apache-2.0"
-repository = "https://github.com/GEOS-ESM/mepo.git"
+license = { file = "LICENSE" }
 requires-python = ">= 3.9"
+
+[project.urls]
+Repository = "https://github.com/GEOS-ESM/mepo"
 
 [project.scripts]
 mepo = "mepo.__main__:main"
 
 [tool.uv]
 managed = true
-dev-dependencies = [
+
+[dependency-groups]
+dev = [
     "black>=24.4.2",
     "pylint>=3.2.0",
     "flake8>=7.0.0",

--- a/src/mepo/cmdline/parser.py
+++ b/src/mepo/cmdline/parser.py
@@ -148,8 +148,7 @@ class MepoArgParser:
             nargs="?",
             default=None,
             choices=[None, "blobless", "treeless"],
-            help=(
-                """
+            help=("""
                 Style of partial clone, default: %(default)s.
                 Allowed options: %(choices)s.
                 None: normal full git clone,
@@ -157,8 +156,7 @@ class MepoArgParser:
                 treeless: cloning with "--filter=tree:0".
                 NOTE: We do *not* recommend using "treeless" as it is very
                 aggressive and will cause problems with many git commands.
-                """
-            ),
+                """),
         )
 
     def __list(self):

--- a/src/mepo/command/config_get.py
+++ b/src/mepo/command/config_get.py
@@ -10,9 +10,7 @@ def run(args):
             f"Option [{option}] does not exist in section [{section}] in .mepoconfig"
         )
     value = mepoconfig.get(section, option)
-    print(
-        f"""
+    print(f"""
     [{section}]
     {option} = {value}
-    """
-    )
+    """)

--- a/tests/output/output_branch_list.txt
+++ b/tests/output/output_branch_list.txt
@@ -6,5 +6,6 @@ ecbuild | * (HEAD detached at geos/v1.3.0)
         |   remotes/origin/geos-develop-before-2025May13-merge
         |   remotes/origin/geos/develop
         |   remotes/origin/geos/main
+        |   remotes/origin/geos/release/3.13.1
         |   remotes/origin/master
         |   remotes/origin/mepo-testing-do-not-delete

--- a/tests/test_mepo_clone.py
+++ b/tests/test_mepo_clone.py
@@ -12,7 +12,6 @@ except ImportError:
 import mepo.command.clone as mepo_clone
 import mepo.command.status as mepo_status
 
-
 FIXTURE_NAME = "GEOSfvdycore-mepo-testing"
 FIXTURE_URL = f"https://github.com/pchakraborty/{FIXTURE_NAME}.git"
 TEST_DIR = os.path.dirname(os.path.realpath(__file__))


### PR DESCRIPTION
## Summary

This PR brings several improvements to CI configuration, project metadata, and documentation.

### CI workflow updates

- All workflows now use `actions/checkout@v7` (pinned to SHA)
- All workflows now use `astral-sh/setup-uv` pinned to SHA (`v8.2.0`) with uv `0.11.23` and caching disabled (no `uv.lock` in this repo)
- `run-formatter.yaml` and `run-linter.yaml` now use `uv run` instead of manually activating `.venv`
- `run-tests.yaml`: Python version matrix updated — added 3.13, 3.14, pypy@3.11; removed pypy@3.9; added `fail-fast: false`

### pyproject.toml

- Migrated `[tool.uv] dev-dependencies` to `[dependency-groups] dev` (modern uv standard)
- Fixed `license` field to use inline table format (`{ file = "LICENSE" }`)
- Moved `repository` URL to `[project.urls]`

### Documentation

- Revised Homebrew installation instructions in `README.md`: clarified recommended install method, added guidance on tap trust, and provided tap management commands

### Code formatting

- Reformatted multi-line help strings in `src/mepo/cmdline/parser.py` and print statements in `src/mepo/command/config_get.py` for consistency (black)
- Removed an unnecessary blank line in `tests/test_mepo_clone.py`